### PR TITLE
Summary: Fix Gemini thinking UI validity; enforce Anthropic v4.5 max …

### DIFF
--- a/src/shared/llmCapabilities.ts
+++ b/src/shared/llmCapabilities.ts
@@ -119,3 +119,11 @@ export function buildGeminiThinkingParams(
   // Gemini 2.5 and below: translate into thinkingBudget; off maps to 0.
   return { generationConfig: { thinkingConfig: { thinkingBudget: toGemini25ThinkingBudget(requested) } } };
 }
+
+export function getAnthropicMaxOutputTokens(modelName: string): number | null {
+  const normalized = modelName.trim().toLowerCase();
+  if (!normalized) return null;
+  // Confirmed: Claude v4.5 models support up to 64k output tokens.
+  if (normalized === 'claude-opus-4-5' || normalized === 'claude-sonnet-4-5') return 64_000;
+  return null;
+}


### PR DESCRIPTION
…output

UI: always resolve a concrete default model (from registry) before computing allowed thinking options, so Gemini-3-Pro never shows invalid Thinking settings due to empty/unknown modelName (src/components/workspace/WorkspaceClient.tsx).
UI: when switching providers in the edit modal, clamp/reset editThinking to a supported default for that provider/model (src/components/workspace/WorkspaceClient.tsx).
Anthropic: add model-based max output helper (v4.5 → 64k) in the shared capabilities registry (src/shared/llmCapabilities.ts).
Anthropic: derive default max_tokens from model max output and hard-fail if ANTHROPIC_MAX_TOKENS exceeds the model limit (no silent clamping) (src/server/llm.ts).