### PR TITLE
chore: force node runtime for supabase routes

### DIFF
--- a/PM_DOCS/BUGS.md
+++ b/PM_DOCS/BUGS.md
@@ -1,6 +1,7 @@
 # BACK END
 [ ] Desktop/local PG mode: app routes to `/login` or throws Supabase env errors when `.env.local` is missing, because several pages and API routes still call `createSupabaseServerClient()` in PG mode. This bypasses the intended local auth failsafe and breaks desktop runs. [Open]
 [ ] (optimization) rawResponse is duplicated in PG (`nodes.content_json` + `nodes.raw_response`); consider de-dupe + a history projection so UI payloads stay small.
+[ ] Build warning: Next.js Edge runtime warnings from `middleware.ts` importing Supabase SSR (`@supabase/ssr` → `@supabase/supabase-js` uses Node APIs). App deploys on Node so runtime is OK; warning persists until middleware avoids Supabase or auth gating moves to Node routes. [Noted]
 
 # FRONT END
 

--- a/app/admin/waitlist/page.tsx
+++ b/app/admin/waitlist/page.tsx
@@ -6,6 +6,8 @@ import { approveEmailAction, approveEmailWithFeedbackAction, removeAllowlistEmai
 import { ApproveEmailForm } from './ApproveEmailForm';
 import { AdminSubmitButton } from './AdminSubmitButton';
 
+export const runtime = 'nodejs';
+
 export default async function AdminWaitlistPage() {
   await requireAdminUser();
 

--- a/app/api/profile/password/route.ts
+++ b/app/api/profile/password/route.ts
@@ -5,6 +5,8 @@ import { requireUser } from '@/src/server/auth';
 import { createSupabaseServerActionClient } from '@/src/server/supabase/server';
 import { z } from 'zod';
 
+export const runtime = 'nodejs';
+
 const changePasswordSchema = z
   .object({
     newPassword: z.string().min(8).max(500),

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -3,6 +3,8 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerActionClient } from '@/src/server/supabase/server';
 
+export const runtime = 'nodejs';
+
 function sanitizeRedirectTo(input: string | null): string | null {
   if (!input) return null;
   if (!input.startsWith('/')) return null;

--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -3,6 +3,8 @@
 import { createSupabaseServerActionClient } from '@/src/server/supabase/server';
 import { NextResponse } from 'next/server';
 
+export const runtime = 'nodejs';
+
 export async function POST(request: Request) {
   try {
     const supabase = createSupabaseServerActionClient();

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -3,6 +3,8 @@
 import { ForgotPasswordForm } from './ForgotPasswordForm';
 import { APP_NAME } from '@/src/config/app';
 
+export const runtime = 'nodejs';
+
 function sanitizeRedirectTo(input: string | null): string {
   if (!input) return '/';
   if (!input.startsWith('/')) return '/';
@@ -25,4 +27,3 @@ export default function ForgotPasswordPage({ searchParams }: { searchParams?: { 
     </main>
   );
 }
-

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,6 +4,8 @@ import { LoginForm } from './LoginForm';
 import { APP_NAME } from '@/src/config/app';
 import BranchingTracesBackground from '@/src/components/login/BranchingTracesBackground';
 
+export const runtime = 'nodejs';
+
 function sanitizeRedirectTo(input: string | null): string {
   if (!input) return '/';
   if (!input.startsWith('/')) return '/';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,8 @@ import { getStoreConfig } from '@/src/server/storeConfig';
 import { resolveLLMProvider, type LLMProvider } from '@/src/server/llm';
 import { getEnabledProviders } from '@/src/server/llmConfig';
 
+export const runtime = 'nodejs';
+
 export default async function HomePage() {
   const store = getStoreConfig();
   const normalizeProviderForUi = (provider: LLMProvider) => (provider === 'openai_responses' ? 'openai' : provider);

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -4,6 +4,8 @@ import { requireUser } from '@/src/server/auth';
 import { ProfilePageClient } from '@/src/components/profile/ProfilePageClient';
 import { RailShell } from '@/src/components/layout/RailShell';
 
+export const runtime = 'nodejs';
+
 export default async function ProfilePage() {
   const user = await requireUser();
   return (

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -8,6 +8,8 @@ import { getStoreConfig } from '@/src/server/storeConfig';
 import { requireUser } from '@/src/server/auth';
 import { getEnabledProviders, getOpenAIUseResponses } from '@/src/server/llmConfig';
 
+export const runtime = 'nodejs';
+
 interface ProjectPageProps {
   params: {
     id: string;

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -3,6 +3,8 @@
 import { ResetPasswordForm } from './ResetPasswordForm';
 import { APP_NAME } from '@/src/config/app';
 
+export const runtime = 'nodejs';
+
 function sanitizeRedirectTo(input: string | null): string {
   if (!input) return '/';
   if (!input.startsWith('/')) return '/';
@@ -25,4 +27,3 @@ export default function ResetPasswordPage({ searchParams }: { searchParams?: { r
     </main>
   );
 }
-

--- a/app/waitlist/page.tsx
+++ b/app/waitlist/page.tsx
@@ -5,6 +5,8 @@ import { APP_NAME } from '@/src/config/app';
 import { submitAccessCode, submitWaitlistRequest } from './actions';
 import { WaitlistSubmitButton } from './WaitlistSubmitButton';
 
+export const runtime = 'nodejs';
+
 function sanitizeRedirectTo(input: string | null): string {
   if (!input) return '/waitlist';
   if (!input.startsWith('/')) return '/waitlist';


### PR DESCRIPTION
Pin Node runtime on Supabase-backed pages/routes to avoid Edge incompatibilities and document the remaining middleware warning.

- add runtime = 'nodejs' to auth, profile, waitlist, and workspace pages
- mark supabase auth routes and profile password API as node runtime
- note middleware edge warning in BUGS.md