### PR TITLE
test: Add coverage for auth edge cases, waitlist, and store parity. T…

### DIFF
--- a/PM_DOCS/E2E_TESTING.md
+++ b/PM_DOCS/E2E_TESTING.md
@@ -1,0 +1,88 @@
+<!-- Copyright (c) 2025 Benjamin F. Hall. All rights reserved. -->
+
+# E2E Testing (Playwright)
+
+This repo already depends on `@playwright/test`, but no Playwright config or tests are wired yet.
+This note captures the recommended first-pass setup and a smoke-test sketch.
+
+## Recommended Setup
+
+The API routes use `requireUser`, which only bypasses Supabase in local Postgres mode.
+For E2E tests, prefer local PG mode (no Supabase dependency).
+
+Environment prerequisites:
+- `RT_STORE=pg`
+- `RT_PG_ADAPTER=local`
+- `LOCAL_PG_URL=postgresql://localhost:5432/youruser`
+- `RT_PG_BOOTSTRAP=1` (auto-run migrations)
+- `LLM_DEFAULT_PROVIDER=mock`
+- Disable other providers for deterministic runs.
+
+## Sample Config (Sketch)
+
+Create `playwright.config.ts`:
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  use: {
+    baseURL: 'http://localhost:3000'
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    env: {
+      RT_STORE: 'pg',
+      RT_PG_ADAPTER: 'local',
+      LOCAL_PG_URL: 'postgresql://localhost:5432/youruser',
+      RT_PG_BOOTSTRAP: '1',
+      LLM_DEFAULT_PROVIDER: 'mock',
+      LLM_ENABLE_OPENAI: 'false',
+      LLM_ENABLE_GEMINI: 'false',
+      LLM_ENABLE_ANTHROPIC: 'false'
+    }
+  }
+});
+```
+
+## Smoke Test (Sketch)
+
+Create `tests/e2e/smoke.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('workspace smoke flow', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByLabel('Workspace Name').fill('Playwright Smoke');
+  await page.getByRole('button', { name: 'Create Workspace' }).click();
+
+  await expect(page).toHaveURL(/\/projects\//);
+
+  await page.getByPlaceholder('Ask anything').fill('Hello from Playwright');
+  await page.keyboard.press('Meta+Enter');
+
+  await expect(page.getByText('Hello from Playwright')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Branches' }).click();
+  await page.getByRole('menuitem', { name: 'New branch' }).click();
+  await page.getByLabel('Branch name').fill('pw-branch');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await page.getByRole('button', { name: 'Merge' }).click();
+  await page.getByLabel('Summary').fill('Bring back pw work');
+  await page.getByRole('button', { name: 'Merge branch' }).click();
+
+  await expect(page.getByText('Merge summary')).toBeVisible();
+});
+```
+
+## Notes
+
+- If local PG is not feasible, add a test-only auth bypass (env-guarded) so `requireUser` returns a fixed user in dev/e2e.
+- Update selectors to match current UI labels (e.g., branch/merge menus may differ).
+- Keep the first test short: create → chat → branch → merge.

--- a/PM_DOCS/FRs.md
+++ b/PM_DOCS/FRs.md
@@ -62,8 +62,8 @@
 
 # TESTING
 [ ] Add a Node-environment test suite for server routes (see `PM_DOCS/NODE_TESTS.md`).
+[ ] Add Playwright E2E smoke test coverage (see `PM_DOCS/E2E_TESTING.md`).
 
 # DESKTOP
 [ ] Store LLM provider keys in macOS Keychain instead of local PG vault (use Electron IPC + native keychain bridge).
 [x] Hide password change profile section when we are in desktop env
-

--- a/tests/client/HomePageContent.test.tsx
+++ b/tests/client/HomePageContent.test.tsx
@@ -1,0 +1,123 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HomePageContent } from '@/src/components/home/HomePageContent';
+import { storageKey } from '@/src/config/app';
+
+(globalThis as typeof globalThis & { React?: typeof React }).React = React;
+
+vi.mock('@/src/components/projects/CreateProjectForm', () => ({
+  CreateProjectForm: () => <div data-testid="create-project-form" />
+}));
+
+vi.mock('@/src/components/auth/AuthRailStatus', () => ({
+  AuthRailStatus: () => null
+}));
+
+vi.mock('@/src/components/layout/RailPageLayout', () => ({
+  RailPageLayout: ({ renderRail, renderMain }: { renderRail: (ctx: any) => React.ReactNode; renderMain: (ctx: any) => React.ReactNode }) => {
+    const ctx = { railCollapsed: false, toggleRail: () => {} };
+    return (
+      <div>
+        <div data-testid="rail">{renderRail(ctx)}</div>
+        <div data-testid="main">{renderMain(ctx)}</div>
+      </div>
+    );
+  }
+}));
+
+const projects = [
+  {
+    id: 'p1',
+    name: 'Alpha Workspace',
+    description: 'Alpha description',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    branchName: 'main',
+    nodeCount: 3,
+    lastModified: Date.UTC(2025, 0, 15, 12, 0, 0)
+  },
+  {
+    id: 'p2',
+    name: 'Beta Workspace',
+    description: 'Beta description',
+    createdAt: '2025-01-02T00:00:00.000Z',
+    branchName: 'main',
+    nodeCount: 1,
+    lastModified: Date.UTC(2025, 0, 16, 12, 0, 0)
+  }
+];
+
+const providerOptions = [
+  { id: 'openai', label: 'OpenAI' },
+  { id: 'gemini', label: 'Gemini' }
+] as const;
+
+describe('HomePageContent archive behavior', () => {
+  const archiveKey = storageKey('archived-projects');
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ llmTokens: { openai: { configured: true } } })
+    })) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('archives a project after confirmation and persists localStorage', async () => {
+    const user = userEvent.setup();
+    render(<HomePageContent projects={projects} providerOptions={providerOptions} defaultProvider="openai" />);
+
+    const alphaLink = await screen.findByRole('link', { name: /Alpha Workspace/ });
+    const alphaItem = alphaLink.closest('li');
+    expect(alphaItem).not.toBeNull();
+
+    const archiveButton = within(alphaItem as HTMLElement).getByRole('button', { name: 'Archive workspace' });
+    await user.click(archiveButton);
+    const confirmButton = within(alphaItem as HTMLElement).getByRole('button', { name: 'Confirm archive' });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: /Alpha Workspace/ })).toBeNull();
+      expect(screen.getByText('Archived')).toBeInTheDocument();
+      expect(screen.getByText('Alpha Workspace')).toBeInTheDocument();
+    });
+
+    const stored = window.localStorage.getItem(archiveKey);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored as string)).toEqual(['p1']);
+  });
+
+  it('unarchives a project after confirmation and updates localStorage', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(archiveKey, JSON.stringify(['p1']));
+
+    render(<HomePageContent projects={projects} providerOptions={providerOptions} defaultProvider="openai" />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: /Alpha Workspace/ })).toBeNull();
+      expect(screen.getByText('Archived')).toBeInTheDocument();
+    });
+
+    const unarchiveButton = screen.getByRole('button', { name: 'Unarchive' });
+    await user.click(unarchiveButton);
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /Alpha Workspace/ })).toBeInTheDocument();
+    });
+
+    const stored = window.localStorage.getItem(archiveKey);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored as string)).toEqual([]);
+  });
+});

--- a/tests/client/WorkspaceClient.test.tsx
+++ b/tests/client/WorkspaceClient.test.tsx
@@ -565,6 +565,24 @@ describe('WorkspaceClient', () => {
     });
   });
 
+  it('hydrates and persists the web search toggle', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem('researchtree:websearch:proj-1:feature/phase-2', 'true');
+    render(<WorkspaceClient project={baseProject} initialBranches={baseBranches} defaultProvider="openai" providerOptions={providerOptions} openAIUseResponses={false} />);
+
+    const toggle = await screen.findByRole('button', { name: 'Toggle web search' });
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+      expect(capturedChatOptions?.webSearch).toBe(true);
+    });
+
+    await user.click(toggle);
+    expect(window.localStorage.getItem('researchtree:websearch:proj-1:feature/phase-2')).toBe('false');
+    await waitFor(() => {
+      expect(capturedChatOptions?.webSearch).toBe(false);
+    });
+  });
+
   it('patch-updates graph histories when the graph is visible and history changes', async () => {
     const user = userEvent.setup();
     let currentNodes = [...sampleNodes];

--- a/tests/server/auth-callback-route.test.ts
+++ b/tests/server/auth-callback-route.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '@/app/auth/callback/route';
+
+const mocks = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+  signOut: vi.fn()
+}));
+
+vi.mock('@/src/server/supabase/server', () => ({
+  createSupabaseServerActionClient: () => ({
+    auth: {
+      exchangeCodeForSession: mocks.exchangeCodeForSession,
+      signOut: mocks.signOut
+    }
+  })
+}));
+
+describe('/auth/callback', () => {
+  beforeEach(() => {
+    mocks.exchangeCodeForSession.mockReset();
+    mocks.signOut.mockReset();
+    mocks.exchangeCodeForSession.mockResolvedValue({});
+    mocks.signOut.mockResolvedValue({});
+  });
+
+  it('exchanges the code and signs out after signup confirm', async () => {
+    const res = await GET(
+      new Request('http://localhost/auth/callback?code=abc&flow=signup-confirm&redirectTo=/projects/p1')
+    );
+
+    expect(mocks.exchangeCodeForSession).toHaveBeenCalledWith('abc');
+    expect(mocks.signOut).toHaveBeenCalled();
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toBe('http://localhost/projects/p1');
+  });
+
+  it('sanitizes redirectTo values', async () => {
+    const res = await GET(new Request('http://localhost/auth/callback?redirectTo=https://evil.com'));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toBe('http://localhost/');
+  });
+});

--- a/tests/server/auth-me-route.test.ts
+++ b/tests/server/auth-me-route.test.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect } from 'vitest';
+import { GET } from '@/app/api/auth/me/route';
+
+describe('/api/auth/me', () => {
+  it('returns the current user', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user).toEqual({ id: 'test-user-id', email: 'test@example.com' });
+  });
+});

--- a/tests/server/middleware.test.ts
+++ b/tests/server/middleware.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn()
+}));
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
+    auth: { getUser: mocks.getUser }
+  })
+}));
+
+const originalEnv = { ...process.env };
+
+describe('middleware auth redirects', () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      RT_STORE: 'git',
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon'
+    };
+    mocks.getUser.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('redirects unauthenticated users to login', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await middleware(new NextRequest('http://localhost/projects/p1'));
+    expect(res?.headers.get('location')).toBe('http://localhost/login?redirectTo=%2Fprojects%2Fp1');
+  });
+
+  it('redirects authenticated users away from login', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+    const res = await middleware(new NextRequest('http://localhost/login?redirectTo=/projects/p1'));
+    expect(res?.headers.get('location')).toBe('http://localhost/projects/p1');
+  });
+
+  it('returns 500 when Supabase env is incomplete', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null } });
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    const res = await middleware(new NextRequest('http://localhost/projects/p1'));
+    expect(res?.status).toBe(500);
+    expect(await res?.text()).toBe('Supabase env is incomplete');
+  });
+});

--- a/tests/server/openai-content-blocks.test.ts
+++ b/tests/server/openai-content-blocks.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect } from 'vitest';
+import { buildContentBlocksForProvider } from '@/src/server/llmContentBlocks';
+
+describe('OpenAI content block reconstruction', () => {
+  it('concatenates responses stream deltas into a single text block', () => {
+    const rawEvents = [
+      { type: 'response.output_text.delta', delta: 'Hello ' },
+      { type: 'response.output_text.delta', text: 'world' }
+    ];
+
+    const blocks = buildContentBlocksForProvider({
+      provider: 'openai_responses',
+      rawResponse: rawEvents
+    });
+
+    expect(blocks).toEqual([{ type: 'text', text: 'Hello world' }]);
+  });
+
+  it('concatenates chat completion deltas including array content', () => {
+    const rawEvents = [
+      { choices: [{ delta: { content: 'Hello ' } }] },
+      { choices: [{ delta: { content: [{ type: 'text', text: 'world' }] } }] }
+    ];
+
+    const blocks = buildContentBlocksForProvider({
+      provider: 'openai',
+      rawResponse: rawEvents
+    });
+
+    expect(blocks).toEqual([{ type: 'text', text: 'Hello world' }]);
+  });
+});

--- a/tests/server/profile-llm-keys-route.test.ts
+++ b/tests/server/profile-llm-keys-route.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '@/app/api/profile/llm-keys/route';
+
+const mocks = vi.hoisted(() => ({
+  rtGetUserLlmKeyStatusV1: vi.fn(),
+  rtGetUserLlmKeyServerV1: vi.fn()
+}));
+
+vi.mock('@/src/store/pg/userLlmKeys', () => ({
+  rtGetUserLlmKeyStatusV1: mocks.rtGetUserLlmKeyStatusV1,
+  rtGetUserLlmKeyServerV1: mocks.rtGetUserLlmKeyServerV1
+}));
+
+describe('/api/profile/llm-keys', () => {
+  beforeEach(() => {
+    mocks.rtGetUserLlmKeyStatusV1.mockReset();
+    mocks.rtGetUserLlmKeyServerV1.mockReset();
+  });
+
+  it('returns per-provider readability and configured status', async () => {
+    mocks.rtGetUserLlmKeyStatusV1.mockResolvedValue({
+      hasOpenAI: true,
+      hasGemini: false,
+      hasAnthropic: true,
+      updatedAt: '2025-12-20T00:00:00.000Z'
+    });
+
+    mocks.rtGetUserLlmKeyServerV1.mockImplementation(async ({ provider }: { provider: string }) => {
+      if (provider === 'openai') return 'sk-123';
+      if (provider === 'gemini') return '   ';
+      throw new Error('read error');
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.providers).toEqual({
+      openai: { configured: true, readable: true, error: null },
+      gemini: { configured: false, readable: false, error: null },
+      anthropic: { configured: true, readable: false, error: 'read error' }
+    });
+    expect(body.updatedAt).toBe('2025-12-20T00:00:00.000Z');
+  });
+});

--- a/tests/server/profile-password-route.test.ts
+++ b/tests/server/profile-password-route.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PUT } from '@/app/api/profile/password/route';
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  updateUser: vi.fn()
+}));
+
+vi.mock('@/src/server/supabase/server', () => ({
+  createSupabaseServerActionClient: () => ({
+    auth: {
+      getUser: mocks.getUser,
+      updateUser: mocks.updateUser
+    }
+  })
+}));
+
+describe('/api/profile/password', () => {
+  beforeEach(() => {
+    mocks.getUser.mockReset();
+    mocks.updateUser.mockReset();
+    mocks.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+    mocks.updateUser.mockResolvedValue({ error: null });
+  });
+
+  it('updates the password for same-origin requests', async () => {
+    const res = await PUT(
+      new Request('http://localhost/api/profile/password', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', origin: 'http://localhost' },
+        body: JSON.stringify({ newPassword: 'password123', confirmPassword: 'password123' })
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.updateUser).toHaveBeenCalledWith({ password: 'password123' });
+  });
+
+  it('rejects mismatched passwords', async () => {
+    const res = await PUT(
+      new Request('http://localhost/api/profile/password', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', origin: 'http://localhost' },
+        body: JSON.stringify({ newPassword: 'password123', confirmPassword: 'password124' })
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests from an invalid origin', async () => {
+    const res = await PUT(
+      new Request('http://localhost/api/profile/password', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', origin: 'http://evil.test' },
+        body: JSON.stringify({ newPassword: 'password123', confirmPassword: 'password123' })
+      })
+    );
+
+    expect(res.status).toBe(403);
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/store-parity.test.ts
+++ b/tests/server/store-parity.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET as GETProjects } from '@/app/api/projects/route';
+import { GET as GETBranches } from '@/app/api/projects/[id]/branches/route';
+import { GET as GETHistory } from '@/app/api/projects/[id]/history/route';
+
+const mocks = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  rtListProjectMemberIdsShadowV1: vi.fn(),
+  rtListProjectsShadowV1: vi.fn(),
+  getProject: vi.fn(),
+  listBranches: vi.fn(),
+  getCurrentBranchName: vi.fn(),
+  rtGetCurrentRefShadowV1: vi.fn(),
+  rtListRefsShadowV1: vi.fn(),
+  readNodesFromRef: vi.fn(),
+  rtGetHistoryShadowV1: vi.fn()
+}));
+
+vi.mock('@git/projects', () => ({
+  listProjects: mocks.listProjects,
+  getProject: mocks.getProject
+}));
+
+vi.mock('@/src/store/pg/members', () => ({
+  rtListProjectMemberIdsShadowV1: mocks.rtListProjectMemberIdsShadowV1
+}));
+
+vi.mock('@/src/store/pg/projects', () => ({
+  rtListProjectsShadowV1: mocks.rtListProjectsShadowV1
+}));
+
+vi.mock('@git/branches', () => ({
+  listBranches: mocks.listBranches
+}));
+
+vi.mock('@git/utils', () => ({
+  getCurrentBranchName: mocks.getCurrentBranchName,
+  readNodesFromRef: mocks.readNodesFromRef
+}));
+
+vi.mock('@/src/store/pg/prefs', () => ({
+  rtGetCurrentRefShadowV1: mocks.rtGetCurrentRefShadowV1
+}));
+
+vi.mock('@/src/store/pg/reads', () => ({
+  rtListRefsShadowV1: mocks.rtListRefsShadowV1,
+  rtGetHistoryShadowV1: mocks.rtGetHistoryShadowV1
+}));
+
+function normalizeProjects(projects: Array<{ id: string; name: string; description?: string; createdAt: string }>) {
+  return projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    description: project.description ?? undefined,
+    createdAt: project.createdAt
+  }));
+}
+
+function normalizeBranches(branches: Array<{ name: string; nodeCount: number; isTrunk: boolean }>) {
+  return branches.map((branch) => ({
+    name: branch.name,
+    nodeCount: branch.nodeCount,
+    isTrunk: branch.isTrunk
+  }));
+}
+
+describe('store parity regression', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+  });
+
+  it('projects list returns consistent shape for git and pg', async () => {
+    mocks.listProjects.mockResolvedValue([
+      { id: 'p1', name: 'Project', description: null, createdAt: '2025-01-01T00:00:00.000Z' }
+    ]);
+    mocks.rtListProjectMemberIdsShadowV1.mockResolvedValue(['p1']);
+    mocks.rtListProjectsShadowV1.mockResolvedValue([
+      { id: 'p1', name: 'Project', description: null, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }
+    ]);
+
+    process.env.RT_STORE = 'git';
+    const gitRes = await GETProjects();
+    const gitBody = await gitRes.json();
+
+    process.env.RT_STORE = 'pg';
+    const pgRes = await GETProjects();
+    const pgBody = await pgRes.json();
+
+    expect(normalizeProjects(gitBody.projects)).toEqual(normalizeProjects(pgBody.projects));
+  });
+
+  it('branches list returns consistent shape for git and pg', async () => {
+    mocks.getProject.mockResolvedValue({ id: 'p1' });
+    mocks.listBranches.mockResolvedValue([
+      { name: 'main', headCommit: 'a', nodeCount: 2, isTrunk: true },
+      { name: 'feature', headCommit: 'b', nodeCount: 1, isTrunk: false }
+    ]);
+    mocks.getCurrentBranchName.mockResolvedValue('main');
+    mocks.rtGetCurrentRefShadowV1.mockResolvedValue({ refName: 'main' });
+    mocks.rtListRefsShadowV1.mockResolvedValue([
+      { name: 'main', headCommit: 'a', nodeCount: 2, isTrunk: true },
+      { name: 'feature', headCommit: 'b', nodeCount: 1, isTrunk: false }
+    ]);
+
+    process.env.RT_STORE = 'git';
+    const gitRes = await GETBranches(new Request('http://localhost/api/projects/p1/branches'), { params: { id: 'p1' } });
+    const gitBody = await gitRes.json();
+
+    process.env.RT_STORE = 'pg';
+    const pgRes = await GETBranches(new Request('http://localhost/api/projects/p1/branches'), { params: { id: 'p1' } });
+    const pgBody = await pgRes.json();
+
+    expect(gitBody.currentBranch).toBe(pgBody.currentBranch);
+    expect(normalizeBranches(gitBody.branches)).toEqual(normalizeBranches(pgBody.branches));
+  });
+
+  it('history returns consistent nodes for git and pg', async () => {
+    const nodes = [
+      { id: 'n1', type: 'message', role: 'user', content: 'Hello', timestamp: 1, parent: null },
+      { id: 'n2', type: 'state', content: 'Hidden', timestamp: 2, parent: 'n1' },
+      { id: 'n3', type: 'message', role: 'assistant', content: 'Hi', timestamp: 3, parent: 'n1', rawResponse: { foo: 'bar' } }
+    ];
+
+    mocks.getProject.mockResolvedValue({ id: 'p1' });
+    mocks.readNodesFromRef.mockResolvedValue(nodes);
+    mocks.rtGetCurrentRefShadowV1.mockResolvedValue({ refName: 'main' });
+    mocks.rtGetHistoryShadowV1.mockResolvedValue(nodes.map((node, ordinal) => ({ ordinal, nodeJson: node })));
+
+    process.env.RT_STORE = 'git';
+    const gitRes = await GETHistory(new Request('http://localhost/api/projects/p1/history'), { params: { id: 'p1' } });
+    const gitBody = await gitRes.json();
+
+    process.env.RT_STORE = 'pg';
+    const pgRes = await GETHistory(new Request('http://localhost/api/projects/p1/history'), { params: { id: 'p1' } });
+    const pgBody = await pgRes.json();
+
+    expect(pgBody.nodes).toEqual(gitBody.nodes);
+  });
+});

--- a/tests/server/waitlist-actions.test.ts
+++ b/tests/server/waitlist-actions.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redirect = vi.fn((url: string) => {
+  const error = new Error(`redirect:${url}`) as Error & { digest?: string };
+  error.digest = 'NEXT_REDIRECT';
+  throw error;
+});
+
+const requestWaitlistAccess = vi.fn();
+const redeemAccessCode = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  redirect
+}));
+
+vi.mock('@/src/server/waitlist', () => ({
+  requestWaitlistAccess,
+  redeemAccessCode
+}));
+
+describe('app/waitlist/actions', () => {
+  beforeEach(() => {
+    redirect.mockClear();
+    requestWaitlistAccess.mockReset();
+    redeemAccessCode.mockReset();
+    vi.resetModules();
+  });
+
+  it('redirects with an error when email is missing', async () => {
+    const { submitWaitlistRequest } = await import('@/app/waitlist/actions');
+    const formData = new FormData();
+    formData.set('redirectTo', '/waitlist');
+
+    await expect(submitWaitlistRequest(formData)).rejects.toThrow(
+      'redirect:/waitlist?requested=0&error=Email%20is%20required.'
+    );
+    expect(requestWaitlistAccess).not.toHaveBeenCalled();
+  });
+
+  it('redirects with success after requesting access', async () => {
+    requestWaitlistAccess.mockResolvedValue(undefined);
+    const { submitWaitlistRequest } = await import('@/app/waitlist/actions');
+    const formData = new FormData();
+    formData.set('email', ' Test@Example.com ');
+    formData.set('redirectTo', '/waitlist');
+
+    await expect(submitWaitlistRequest(formData)).rejects.toThrow(
+      'redirect:/waitlist?requested=1&email=Test%40Example.com'
+    );
+    expect(requestWaitlistAccess).toHaveBeenCalledWith('Test@Example.com');
+  });
+
+  it('redirects with an error when waitlist request fails', async () => {
+    requestWaitlistAccess.mockRejectedValue(new Error('boom'));
+    const { submitWaitlistRequest } = await import('@/app/waitlist/actions');
+    const formData = new FormData();
+    formData.set('email', 'user@example.com');
+    formData.set('redirectTo', '/waitlist');
+
+    await expect(submitWaitlistRequest(formData)).rejects.toThrow(
+      'redirect:/waitlist?requested=0&error=boom'
+    );
+  });
+
+  it('redirects with an error when email or code is missing', async () => {
+    const { submitAccessCode } = await import('@/app/waitlist/actions');
+    const formData = new FormData();
+    formData.set('email', 'user@example.com');
+    formData.set('redirectTo', '/waitlist');
+
+    await expect(submitAccessCode(formData)).rejects.toThrow(
+      'redirect:/waitlist?codeApplied=0&error=Email%20and%20access%20code%20are%20required.'
+    );
+    expect(redeemAccessCode).not.toHaveBeenCalled();
+  });
+
+  it('redirects with an error when the access code is invalid', async () => {
+    redeemAccessCode.mockResolvedValue(false);
+    const { submitAccessCode } = await import('@/app/waitlist/actions');
+    const formData = new FormData();
+    formData.set('email', 'user@example.com');
+    formData.set('code', 'nope');
+    formData.set('redirectTo', '/waitlist');
+
+    await expect(submitAccessCode(formData)).rejects.toThrow(
+      'redirect:/waitlist?codeApplied=0&error=Invalid%20or%20exhausted%20access%20code.'
+    );
+  });
+
+  it('redirects with success when the access code is redeemed', async () => {
+    redeemAccessCode.mockResolvedValue(true);
+    const { submitAccessCode } = await import('@/app/waitlist/actions');
+    const formData = new FormData();
+    formData.set('email', ' user@example.com ');
+    formData.set('code', ' CODE ');
+    formData.set('redirectTo', '/waitlist');
+
+    await expect(submitAccessCode(formData)).rejects.toThrow(
+      'redirect:/waitlist?codeApplied=1&email=user%40example.com'
+    );
+    expect(redeemAccessCode).toHaveBeenCalledWith('user@example.com', 'CODE');
+  });
+});

--- a/tests/server/waitlist.test.ts
+++ b/tests/server/waitlist.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isEmailWhitelisted,
+  checkEmailAllowedForAuth,
+  requestWaitlistAccess,
+  approveEmail,
+  redeemAccessCode
+} from '@/src/server/waitlist';
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  rpc: vi.fn()
+}));
+
+vi.mock('@/src/server/supabase/admin', () => ({
+  createSupabaseAdminClient: () => ({
+    from: mocks.from,
+    rpc: mocks.rpc
+  })
+}));
+
+const originalEnv = { ...process.env };
+
+describe('waitlist helpers', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    mocks.from.mockReset();
+    mocks.rpc.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('skips allowlist checks when the waitlist is disabled', async () => {
+    process.env.RT_WAITLIST_ENFORCE = 'false';
+    const allowed = await isEmailWhitelisted('Test@Example.com');
+    expect(allowed).toBe(true);
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
+  it('returns false when email is not on the allowlist', async () => {
+    process.env.RT_WAITLIST_ENFORCE = '1';
+    const chain = {
+      eq: vi.fn(() => chain),
+      maybeSingle: vi.fn(async () => ({ data: null, error: null }))
+    };
+    const allowlist = { select: vi.fn(() => chain) };
+    mocks.from.mockReturnValue(allowlist);
+
+    const allowed = await isEmailWhitelisted('  Test@Example.com ');
+    expect(allowed).toBe(false);
+    expect(chain.eq).toHaveBeenCalledWith('email', 'test@example.com');
+  });
+
+  it('rejects empty email in auth gate checks', async () => {
+    process.env.RT_WAITLIST_ENFORCE = '1';
+    const result = await checkEmailAllowedForAuth('   ');
+    expect(result.allowed).toBe(false);
+    expect(result.error).toBe('Email is required.');
+  });
+
+  it('returns a waitlist error when access is not granted', async () => {
+    process.env.RT_WAITLIST_ENFORCE = 'true';
+    const chain = {
+      eq: vi.fn(() => chain),
+      maybeSingle: vi.fn(async () => ({ data: null, error: null }))
+    };
+    const allowlist = { select: vi.fn(() => chain) };
+    mocks.from.mockReturnValue(allowlist);
+
+    const result = await checkEmailAllowedForAuth('user@example.com');
+    expect(result.allowed).toBe(false);
+    expect(result.error).toMatch(/invite-only/i);
+  });
+
+  it('inserts a waitlist request when none exists', async () => {
+    process.env.RT_WAITLIST_ENFORCE = 'true';
+    const selectChain = {
+      eq: vi.fn(() => selectChain),
+      maybeSingle: vi.fn(async () => ({ data: null, error: null }))
+    };
+    const insert = vi.fn(async () => ({ error: null }));
+    const waitlist = {
+      select: vi.fn(() => selectChain),
+      insert
+    };
+    mocks.from.mockReturnValue(waitlist);
+
+    await requestWaitlistAccess('  Test@Example.com ');
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'test@example.com',
+        status: 'pending',
+        request_count: 1,
+        last_requested_at: expect.any(String)
+      })
+    );
+  });
+
+  it('updates an existing waitlist request count', async () => {
+    process.env.RT_WAITLIST_ENFORCE = 'true';
+    const selectChain = {
+      eq: vi.fn(() => selectChain),
+      maybeSingle: vi.fn(async () => ({ data: { request_count: 3 }, error: null }))
+    };
+    const updateEq = vi.fn(async () => ({ error: null }));
+    const update = vi.fn(() => ({ eq: updateEq }));
+    const waitlist = {
+      select: vi.fn(() => selectChain),
+      update
+    };
+    mocks.from.mockReturnValue(waitlist);
+
+    await requestWaitlistAccess('Test@Example.com');
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request_count: 4,
+        last_requested_at: expect.any(String)
+      })
+    );
+    expect(updateEq).toHaveBeenCalledWith('email', 'test@example.com');
+  });
+
+  it('approves an email and updates waitlist state', async () => {
+    process.env.RT_WAITLIST_ENFORCE = 'true';
+    const allowlist = {
+      upsert: vi.fn(async () => ({ error: null }))
+    };
+    const updateEq = vi.fn(async () => ({ error: null }));
+    const waitlist = {
+      update: vi.fn(() => ({ eq: updateEq }))
+    };
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'email_allowlist') return allowlist;
+      if (table === 'waitlist_requests') return waitlist;
+      return {};
+    });
+
+    await approveEmail(' Test@Example.com ', ' Admin@Example.com ');
+    expect(allowlist.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'test@example.com',
+        created_by: 'admin@example.com'
+      }),
+      { onConflict: 'email' }
+    );
+    expect(updateEq).toHaveBeenCalledWith('email', 'test@example.com');
+  });
+
+  it('redeems access codes via RPC', async () => {
+    mocks.rpc.mockResolvedValue({ data: true, error: null });
+    const ok = await redeemAccessCode(' User@Example.com ', ' CODE ');
+    expect(ok).toBe(true);
+    expect(mocks.rpc).toHaveBeenCalledWith('rt_redeem_access_code_v1', {
+      p_code: 'code',
+      p_email: 'user@example.com',
+      p_approved_by: null
+    });
+  });
+
+  it('rejects empty access codes', async () => {
+    await expect(redeemAccessCode('user@example.com', '  ')).rejects.toThrow('Access code is required.');
+  });
+});

--- a/tests/store/pg/local-adapter.integration.test.ts
+++ b/tests/store/pg/local-adapter.integration.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { rtCreateProjectShadow, rtListProjectsShadowV1 } from '@/src/store/pg/projects';
+import { rtAppendNodeToRefShadowV1 } from '@/src/store/pg/nodes';
+
+const mocks = vi.hoisted(() => ({
+  createLocalPgAdapter: vi.fn()
+}));
+
+vi.mock('@/src/store/pg/localAdapter', () => ({
+  createLocalPgAdapter: mocks.createLocalPgAdapter
+}));
+
+const originalEnv = { ...process.env };
+
+describe('local pg adapter integration (smoke)', () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      RT_PG_ADAPTER: 'local',
+      LOCAL_PG_URL: 'postgresql://localhost:5432/test'
+    };
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    mocks.createLocalPgAdapter.mockReset();
+    mocks.createLocalPgAdapter.mockReturnValue({
+      rpc: async (fn: string) => {
+        if (fn === 'rt_create_project') {
+          return { data: 'proj-1', error: null };
+        }
+        if (fn === 'rt_list_projects_v1') {
+          return {
+            data: [
+              {
+                id: 'proj-1',
+                name: 'Local',
+                description: null,
+                created_at: '2025-01-01T00:00:00Z',
+                updated_at: null
+              }
+            ],
+            error: null
+          };
+        }
+        if (fn === 'rt_append_node_to_ref_v1') {
+          return {
+            data: [
+              {
+                new_commit_id: 'c1',
+                node_id: 'n1',
+                ordinal: 0,
+                artefact_id: null,
+                artefact_content_hash: null
+              }
+            ],
+            error: null
+          };
+        }
+        return { data: null, error: null };
+      },
+      adminRpc: async () => ({ data: null, error: null })
+    });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('executes RPC wrappers through the local adapter', async () => {
+    const created = await rtCreateProjectShadow({ name: 'Local Project' });
+    expect(created.projectId).toBe('proj-1');
+
+    const projects = await rtListProjectsShadowV1();
+    expect(projects).toEqual([
+      {
+        id: 'proj-1',
+        name: 'Local',
+        description: undefined,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z'
+      }
+    ]);
+
+    const appended = await rtAppendNodeToRefShadowV1({
+      projectId: 'proj-1',
+      refName: 'main',
+      kind: 'message',
+      role: 'user',
+      contentJson: { text: 'hello' }
+    });
+    expect(appended).toEqual({
+      newCommitId: 'c1',
+      nodeId: 'n1',
+      ordinal: 0,
+      artefactId: null,
+      artefactContentHash: null
+    });
+
+    expect(mocks.createLocalPgAdapter).toHaveBeenCalledWith(expect.objectContaining({ bootstrap: expect.any(Function) }));
+  });
+});


### PR DESCRIPTION
…his adds low-lift regression coverage plus local PG smoke tests to prevent core flow drift.

- add waitlist helper + action tests covering allowlist, requests, approvals, and access codes
- add middleware/auth/password edge-case tests
- add store parity checks for projects/branches/history responses in git vs pg
- add local PG adapter smoke test and OpenAI content block parsing tests
- add home archive + web search toggle client tests
- document Playwright E2E setup and track FR item