### PR TITLE
fix: guard phase 3 ref_id enforcement

### DIFF
--- a/PM_DOCS/BUGS.md
+++ b/PM_DOCS/BUGS.md
@@ -31,6 +31,7 @@
 [x] if a user has entered provider API token but hits a quota issue with the provider, we surface a generic errors. We need to detect this response for each provider and surface a clear user facing error.
 [x] double check that we surface a clear user facing error if user tries a provider and has not entered an api token for that provider.
 [x] excess horizontal padding around the chat/graph container <div class="flex h-full min-h-0 min-w-0 flex-col gap-6 lg:flex-row lg:gap-0">
+[ ] gemini replies initially stream thinking content into chat view. Once complete, thinking is contained (corrrectly) in thinking box, and only reply content shows. This initial state is a bug.
 
 ### Branches
 [x] LLM config should be pinned to branch [Fixed - provider/thinking persisted per `projectId + branchName` storage keys]

--- a/PM_DOCS/PG_REFS_POST_MERGE_VERIFY.md
+++ b/PM_DOCS/PG_REFS_POST_MERGE_VERIFY.md
@@ -234,7 +234,7 @@ where ref_id is null;
 
 [
   {
-    "artefacts_missing_ref_id": 1
+    "artefacts_missing_ref_id": 0
   }
 ]
 
@@ -250,6 +250,8 @@ Note: Backfill picks one ref per commit using `commit_order` (highest ordinal, t
 
 ## Phase 3: Cleanup Verification (after ref_name removal)
 
+Note: `20251231003230_rt_ref_id_phase3_cleanup.sql` now includes a defensive artefacts backfill + guard before `ref_id` NOT NULL. This is to protect prod if Phase 1 didn’t fully backfill; do not re-run on dev once applied.
+
 ### 1) Confirm legacy ref_name columns are gone
 
 ```sql
@@ -262,17 +264,7 @@ where table_schema = 'public'
 
 Expect: zero rows.
 
-[
-  {
-    "column_name": "ref_name"
-  },
-  {
-    "column_name": "ref_name"
-  },
-  {
-    "column_name": "current_ref_name"
-  }
-]
+Success. No rows returned 
 
 ### 2) Confirm ref_id is not null
 
@@ -309,7 +301,7 @@ where ref_id is null;
 
 [
   {
-    "artefacts_null_ref_id": 1
+    "artefacts_null_ref_id": 0
   }
 ]
 
@@ -328,19 +320,22 @@ where conname in (
   'refs_project_id_name_key'
 );
 ```
-
 [
   {
-    "conname": "artefact_drafts_pkey",
-    "conrelid": "artefact_drafts"
+    "conname": "refs_pkey",
+    "conrelid": "refs"
   },
   {
     "conname": "commit_order_pkey",
     "conrelid": "commit_order"
   },
   {
-    "conname": "refs_pkey",
-    "conrelid": "refs"
+    "conname": "commit_order_project_id_ref_id_commit_id_key",
+    "conrelid": "commit_order"
+  },
+  {
+    "conname": "artefact_drafts_pkey",
+    "conrelid": "artefact_drafts"
   }
 ]
 


### PR DESCRIPTION
Add a defensive artefacts ref_id backfill plus a hard guard before enforcing NOT NULL, and update verification notes/results.

- backfill artefacts.ref_id using commit_order before NOT NULL
- raise an explicit exception if any ref_id remains null
- document the guard and rerun verification outcomes