### PR TITLE
fix: tighten auth sign-in hooks and enforce password policy

### DIFF
--- a/PM_DOCS/BUGS.md
+++ b/PM_DOCS/BUGS.md
@@ -6,7 +6,13 @@
 # FRONT END
 
 ## REGISTRATION & LOGIN
-[x] if a user attempts to create an account with an email that's already registered, the UI hits a dead end and provides no feedback
+[x][reverify] if a user attempts to create an account with an email that's already registered, the UI hits a dead end and provides no feedback
+[ ] when user clicks confirm email link in email, should send them to "existing user" view
+[ ] when user triggers password reset, email link takes them to new user registration view
+[ ] when returning user (existing but expired/cancelled cookie) lands on login page, best efforts to show them sign in view, not new user view
+[ ] when new user enters non-compliant password, need to block submission and registration - does/should supabase return error in this case?
+[ ] allow magic link sign in?
+
 
 
 ## HOME

--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -13,5 +13,5 @@ export async function POST(request: Request) {
     // ignore
   }
   const url = new URL(request.url);
-  return NextResponse.redirect(new URL('/login', url.origin), { status: 303 });
+  return NextResponse.redirect(new URL('/login?mode=signIn#existing-user', url.origin), { status: 303 });
 }

--- a/app/check-email/page.tsx
+++ b/app/check-email/page.tsx
@@ -32,6 +32,7 @@ export default function CheckEmailPage({
   const loginParams = new URLSearchParams();
   loginParams.set('redirectTo', redirectTo);
   if (email) loginParams.set('email', email);
+  loginParams.set('mode', 'signIn');
   const loginHref = `/login?${loginParams.toString()}#existing-user`;
 
   return (

--- a/app/forgot-password/ForgotPasswordForm.tsx
+++ b/app/forgot-password/ForgotPasswordForm.tsx
@@ -53,7 +53,10 @@ export function ForgotPasswordForm({ redirectTo }: { redirectTo: string }) {
 
         <div className="flex items-center justify-between gap-3">
           <SubmitButton />
-          <Link href={`/login?redirectTo=${encodeURIComponent(redirectTo)}`} className="text-sm text-slate-900 underline">
+          <Link
+            href={`/login?redirectTo=${encodeURIComponent(redirectTo)}&mode=signIn#existing-user`}
+            className="text-sm text-slate-900 underline"
+          >
             Back to sign in
           </Link>
         </div>

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -15,12 +15,20 @@ function sanitizeRedirectTo(input: string | null): string | null {
   return input;
 }
 
+function ensureSignInModeForLogin(redirectTo: string): string {
+  if (!redirectTo.startsWith('/login')) return redirectTo;
+  const url = new URL(redirectTo, 'http://local');
+  url.searchParams.set('mode', 'signIn');
+  return `${url.pathname}?${url.searchParams.toString()}`;
+}
+
 export async function requestPasswordReset(
   _prevState: PasswordResetActionState,
   formData: FormData
 ): Promise<PasswordResetActionState> {
   const email = String(formData.get('email') ?? '').trim();
-  const redirectTo = sanitizeRedirectTo(String(formData.get('redirectTo') ?? '').trim()) ?? '/';
+  const redirectTo =
+    ensureSignInModeForLogin(sanitizeRedirectTo(String(formData.get('redirectTo') ?? '').trim()) ?? '/');
 
   if (!email) {
     return { error: 'Email is required.' };

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -29,9 +29,14 @@ function isWaitlistEnforced(): boolean {
   return !['0', 'false', 'off', 'no'].includes(raw);
 }
 
-export default function LoginPage({ searchParams }: { searchParams?: { redirectTo?: string; email?: string } }) {
+export default function LoginPage({
+  searchParams
+}: {
+  searchParams?: { redirectTo?: string; email?: string; mode?: string };
+}) {
   const redirectTo = sanitizeRedirectTo(searchParams?.redirectTo ?? null);
   const prefillEmail = sanitizePrefillEmail(searchParams?.email ?? null);
+  const initialMode = searchParams?.mode === 'signIn' ? 'signIn' : 'signUp';
   const waitlistEnforced = isWaitlistEnforced();
   return (
     <main className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(226,232,255,0.7),_rgba(248,250,252,0.95)_48%,_rgba(255,255,255,1)_100%)] px-6 py-12">
@@ -45,7 +50,12 @@ export default function LoginPage({ searchParams }: { searchParams?: { redirectT
           </p>
         </div>
         <div className="w-full max-w-sm">
-          <LoginForm redirectTo={redirectTo} initialEmail={prefillEmail} waitlistEnforced={waitlistEnforced} />
+          <LoginForm
+            redirectTo={redirectTo}
+            initialEmail={prefillEmail}
+            initialMode={initialMode}
+            waitlistEnforced={waitlistEnforced}
+          />
         </div>
       </div>
     </main>

--- a/app/reset-password/ResetPasswordForm.tsx
+++ b/app/reset-password/ResetPasswordForm.tsx
@@ -5,6 +5,7 @@
 import { useFormState, useFormStatus } from 'react-dom';
 import Link from 'next/link';
 import { updatePassword } from './actions';
+import { PASSWORD_MIN_LENGTH, PASSWORD_POLICY_HINT } from '@/src/utils/passwordPolicy';
 
 const initialState = { error: null as string | null };
 
@@ -47,8 +48,11 @@ export function ResetPasswordForm({ redirectTo }: { redirectTo: string }) {
             type="password"
             autoComplete="new-password"
             required
-            minLength={8}
+            minLength={PASSWORD_MIN_LENGTH}
+            pattern={`(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{${PASSWORD_MIN_LENGTH},}`}
+            title={PASSWORD_POLICY_HINT}
           />
+          <span className="mt-1 block text-xs text-slate-600">{PASSWORD_POLICY_HINT}</span>
         </label>
         <label className="block">
           <span className="text-sm font-medium text-slate-800">Confirm password</span>
@@ -58,7 +62,7 @@ export function ResetPasswordForm({ redirectTo }: { redirectTo: string }) {
             type="password"
             autoComplete="new-password"
             required
-            minLength={8}
+            minLength={PASSWORD_MIN_LENGTH}
           />
         </label>
 
@@ -66,7 +70,10 @@ export function ResetPasswordForm({ redirectTo }: { redirectTo: string }) {
 
         <div className="flex items-center justify-between gap-3">
           <SubmitButton />
-          <Link href={`/login?redirectTo=${encodeURIComponent(redirectTo)}`} className="text-sm text-slate-900 underline">
+          <Link
+            href={`/login?redirectTo=${encodeURIComponent(redirectTo)}&mode=signIn#existing-user`}
+            className="text-sm text-slate-900 underline"
+          >
             Back to sign in
           </Link>
         </div>

--- a/app/reset-password/actions.ts
+++ b/app/reset-password/actions.ts
@@ -4,6 +4,7 @@
 
 import { redirect } from 'next/navigation';
 import { createSupabaseServerActionClient } from '@/src/server/supabase/server';
+import { getPasswordPolicyError } from '@/src/utils/passwordPolicy';
 
 type ResetPasswordActionState = { error: string | null };
 
@@ -22,8 +23,8 @@ export async function updatePassword(
   const confirmPassword = String(formData.get('confirmPassword') ?? '');
   const redirectTo = sanitizeRedirectTo(String(formData.get('redirectTo') ?? '').trim()) ?? '/';
 
-  if (!password) return { error: 'Password is required.' };
-  if (password.length < 8) return { error: 'Password must be at least 8 characters.' };
+  const passwordError = getPasswordPolicyError(password);
+  if (passwordError) return { error: passwordError };
   if (password !== confirmPassword) return { error: 'Passwords do not match.' };
 
   try {
@@ -44,4 +45,3 @@ export async function updatePassword(
   redirect(redirectTo);
   return { error: null };
 }
-

--- a/app/waitlist/page.tsx
+++ b/app/waitlist/page.tsx
@@ -109,7 +109,7 @@ export default function WaitlistPage({
 
           <div className="flex flex-wrap items-center gap-3">
             <Link
-              href="/login"
+              href="/login?mode=signIn#existing-user"
               className="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-900 hover:bg-slate-50"
             >
               Back to sign in

--- a/src/utils/passwordPolicy.ts
+++ b/src/utils/passwordPolicy.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+export const PASSWORD_MIN_LENGTH = 10;
+const PASSWORD_POLICY_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{10,}$/;
+
+export function getPasswordPolicyError(password: string): string | null {
+  if (!password) return 'Password is required.';
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${PASSWORD_MIN_LENGTH} characters.`;
+  }
+  if (!PASSWORD_POLICY_REGEX.test(password)) {
+    return 'Password must include lowercase and uppercase letters, a digit, and a symbol.';
+  }
+  return null;
+}
+
+export const PASSWORD_POLICY_HINT =
+  'Minimum 10 characters. Use lowercase and uppercase letters, digits, and symbols.';

--- a/tests/server/reset-password-actions.test.ts
+++ b/tests/server/reset-password-actions.test.ts
@@ -27,8 +27,8 @@ describe('app/reset-password/actions updatePassword', () => {
   it('returns an error when passwords do not match', async () => {
     const { updatePassword } = await import('@/app/reset-password/actions');
     const formData = new FormData();
-    formData.set('password', 'password123');
-    formData.set('confirmPassword', 'different');
+    formData.set('password', 'ValidPass1!');
+    formData.set('confirmPassword', 'Different1!');
     formData.set('redirectTo', '/');
 
     const result = await updatePassword({ error: null }, formData);
@@ -43,8 +43,8 @@ describe('app/reset-password/actions updatePassword', () => {
 
     const { updatePassword } = await import('@/app/reset-password/actions');
     const formData = new FormData();
-    formData.set('password', 'password123');
-    formData.set('confirmPassword', 'password123');
+    formData.set('password', 'ValidPass1!');
+    formData.set('confirmPassword', 'ValidPass1!');
     formData.set('redirectTo', '/');
 
     const result = await updatePassword({ error: null }, formData);
@@ -60,15 +60,14 @@ describe('app/reset-password/actions updatePassword', () => {
 
     const { updatePassword } = await import('@/app/reset-password/actions');
     const formData = new FormData();
-    formData.set('password', 'password123');
-    formData.set('confirmPassword', 'password123');
+    formData.set('password', 'ValidPass1!');
+    formData.set('confirmPassword', 'ValidPass1!');
     formData.set('redirectTo', '/dashboard');
 
     const result = await updatePassword({ error: null }, formData);
 
     expect(result.error).toBeNull();
-    expect(updateUser).toHaveBeenCalledWith({ password: 'password123' });
+    expect(updateUser).toHaveBeenCalledWith({ password: 'ValidPass1!' });
     expect(redirect).toHaveBeenCalledWith('/dashboard');
   });
 });
-


### PR DESCRIPTION
Align deliberate sign-in redirects with existing-user flows and enforce the configured password requirements across sign-up and reset.

add a shared password policy helper with min length and symbol/upper/lower/digit checks preserve sign-up error feedback when flipping to sign-in mode standardize sign-in entry points with mode=signIn across auth links and callbacks update reset flow to preserve sign-in mode when redirecting to login adjust reset-password tests to use compliant passwords