### PR TITLE
fix: refine rail layout and branch controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,8 @@
+## Product Manager Docs
+We plan and track progress in PM_DOCS/
+We track feature requets in PM_DOCS/FRs.md
+We track bugs in PM_DOCS/BUGS.md
+
 ## Supabase migration files
  - The file MUST be named in the format YYYYMMDDHHmmss_short_description.sql with proper casing for months, minutes, and seconds in UTC time.
 

--- a/PM_DOCS/BUGS.md
+++ b/PM_DOCS/BUGS.md
@@ -23,6 +23,7 @@
 [ ] on page load (home, workspace) rail renders as open and then closes, causing a flicker.
 [ ] home - recent list must scroll after flexing into Archive section (currently forces everything below off the page)
 [ ] home - archive pushes user button off bottom of page when expanded (see screenshot)
+[ ] home - when archive is expanded, it disappears off the bottom of the page
 
 ## WORKSPACE / PROJECT
 [x] workspace UI sometimes refers to main, sometimes to trunk

--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -130,13 +130,12 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
       <RailPageLayout
         renderRail={({ railCollapsed, toggleRail }) =>
           !railCollapsed ? (
-            <div className="mt-6 flex flex-1 flex-col gap-3">
+            <div className="mt-6 flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
               <div className="rounded-full bg-white/90 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary shadow-sm">
                 Workspaces
               </div>
-              <div className="flex-1 min-h-0 overflow-hidden pr-1">
-                <div className="flex h-full flex-col gap-4">
-                  <div className="flex min-h-0 flex-1 flex-col gap-2">
+              <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+                  <div className={`flex min-h-0 flex-1 flex-col gap-2 ${archivedProjects.length > 0 ? 'border-b border-divider/60 pb-3' : ''}`}>
                     <div className="text-xs font-semibold uppercase tracking-wide text-muted">Recent</div>
                     {recentProjects.length === 0 ? (
                       <p className="rounded-xl border border-divider/60 bg-white/80 px-3 py-2 text-xs text-muted shadow-sm">
@@ -193,7 +192,11 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                     )}
                   </div>
                   {archivedProjects.length > 0 ? (
-                    <div className={`flex min-h-0 flex-col gap-2 border-t border-divider/60 pt-3 ${showArchived ? 'flex-1' : ''}`}>
+                    <div
+                      className={`flex min-h-0 flex-col gap-2 pt-2 ${
+                        showArchived ? 'h-[66%]' : ''
+                      }`}
+                    >
                       <button
                         type="button"
                         onClick={() => setShowArchived((prev) => !prev)}
@@ -262,7 +265,6 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                       ) : null}
                     </div>
                   ) : null}
-                </div>
               </div>
 
               <div className="mt-auto flex items-start pb-2">

--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2037,17 +2037,7 @@ export function WorkspaceClient({
                               {displayBranchName(branch.name)}
                             </span>
                           </span>
-                          <span className="inline-flex items-center gap-2">
-                            {branch.isPinned ? (
-                              <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                                Pinned
-                              </span>
-                            ) : null}
-                            {branchName === branch.name ? (
-                              <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-semibold text-slate-600">
-                                Current
-                              </span>
-                            ) : null}
+                          <span className="inline-flex items-center gap-1">
                             <button
                               type="button"
                               onClick={(event) => {
@@ -2055,11 +2045,12 @@ export function WorkspaceClient({
                                 void togglePinnedBranch(branch);
                               }}
                               disabled={isSwitching || isCreating || isPinning}
-                              className="inline-flex items-center gap-1 rounded-full border border-divider/80 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-600 shadow-sm hover:bg-primary/10 disabled:opacity-60"
+                              className={`inline-flex h-7 w-7 items-center justify-center rounded-full border border-divider/80 bg-white shadow-sm transition ${
+                                isSwitching || isCreating || isPinning ? 'cursor-not-allowed' : 'hover:bg-primary/10'
+                              } ${branch.isPinned ? 'text-red-600 hover:text-red-700' : 'text-slate-400 hover:text-slate-600'}`}
                               aria-label={branch.isPinned ? 'Unpin branch' : 'Pin branch'}
                             >
-                              <BlueprintIcon icon="pin" className="h-3 w-3" />
-                              <span>{branch.isPinned ? 'Unpin' : 'Pin'}</span>
+                              <BlueprintIcon icon="pin" className="h-3.5 w-3.5" />
                             </button>
                             <button
                               type="button"
@@ -2068,11 +2059,14 @@ export function WorkspaceClient({
                                 openRenameModal(branch);
                               }}
                               disabled={branch.isTrunk || isSwitching || isCreating || isPinning}
-                              className="inline-flex items-center gap-1 rounded-full border border-divider/80 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-600 shadow-sm hover:bg-primary/10 disabled:opacity-60"
+                              className={`inline-flex h-7 w-7 items-center justify-center rounded-full border border-divider/80 bg-white shadow-sm transition ${
+                                branch.isTrunk || isSwitching || isCreating || isPinning
+                                  ? 'cursor-not-allowed text-slate-300'
+                                  : 'text-slate-500 hover:bg-primary/10 hover:text-slate-700'
+                              }`}
                               aria-label="Rename branch"
                             >
-                              <BlueprintIcon icon="edit" className="h-3 w-3" />
-                              <span>Rename</span>
+                              <BlueprintIcon icon="edit" className="h-3.5 w-3.5" />
                             </button>
                           </span>
                         </div>


### PR DESCRIPTION
Update the home rail layout and branch controls to reduce visual clutter and improve scrolling behavior. Align project docs and bug tracking notes with the latest UI changes.

- adjust home rail recent/archive sizing, dividers, and scroll regions

- simplify branch rail actions to icon-only pin/rename with active and disabled styling

- add PM docs notes for product management tracking and the new archive visibility bug