### PR TITLE
test: harden Playwright smoke for CI timing

### DIFF
--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -41,7 +41,7 @@ async function waitForStreamingIdle(page: Page) {
 
 async function expectActiveBranch(page: Page, branchName: string) {
   const branchButton = page.locator(`[data-testid="branch-switch"][data-branch-name="${branchName}"]`);
-  await expect(branchButton.getByText('Current', { exact: true })).toBeVisible();
+  await expect(branchButton).toHaveAttribute('data-branch-current', 'true');
 }
 
 async function switchToBranch(page: Page, branchName: string) {


### PR DESCRIPTION
Improves e2e stability by waiting for branch switches, provider options, and merge diff readiness in CI. Reorders readiness checks to favor UI anchors before URL assertions.

- wait for branches POST response during branch switches
- guard provider selection with option presence checks
- assert chat list visibility before relying on URL
- extend merge diff assertion timeout