### PR TITLE
fix: stabilize rail auth + pin UX

### DIFF
--- a/PM_DOCS/BUGS.md
+++ b/PM_DOCS/BUGS.md
@@ -21,9 +21,9 @@
 
 [x] models are now pinned immutably to branches - this means that a user now has no opportunity to choose provider for the main/trunk branch when creating a new project. 
 [ ] on page load (home, workspace) rail renders as open and then closes, causing a flicker.
-[ ] home - recent list must scroll after flexing into Archive section (currently forces everything below off the page)
-[ ] home - archive pushes user button off bottom of page when expanded (see screenshot)
-[ ] home - when archive is expanded, it disappears off the bottom of the page
+[x] home - recent list must scroll after flexing into Archive section (currently forces everything below off the page)
+[x] home - archive pushes user button off bottom of page when expanded (see screenshot)
+[x] home - when archive is expanded, it disappears off the bottom of the page
 
 ## WORKSPACE / PROJECT
 [x] workspace UI sometimes refers to main, sometimes to trunk
@@ -41,6 +41,8 @@
 [x] double check that we surface a clear user facing error if user tries a provider and has not entered an api token for that provider.
 [x] excess horizontal padding around the chat/graph container <div class="flex h-full min-h-0 min-w-0 flex-col gap-6 lg:flex-row lg:gap-0">
 [ ] gemini replies initially stream thinking content into chat view. Once complete, thinking is contained (corrrectly) in thinking box, and only reply content shows. This initial state is a bug.
+[x] toggling the rail fires an auth request [Fixed - keep AuthRailStatus mounted across rail toggles.]
+[x] pinning a branch instantly fires a request and triggers spinner - a bit laggy. Should copy our pattern from stars (seems nicer ui/ux) [Fixed - optimistic pin updates + per-button pending indicator.]
 
 ### Branches
 [x] LLM config should be pinned to branch [Fixed - provider/thinking persisted per `projectId + branchName` storage keys]

--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -128,133 +128,61 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
   return (
     <>
       <RailPageLayout
-        renderRail={({ railCollapsed, toggleRail }) =>
-          !railCollapsed ? (
-            <div className="mt-6 flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
-              <div className="rounded-full bg-white/90 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary shadow-sm">
-                Workspaces
-              </div>
-              <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
-                  <div className={`flex min-h-0 flex-1 flex-col gap-2 ${archivedProjects.length > 0 ? 'border-b border-divider/60 pb-3' : ''}`}>
-                    <div className="text-xs font-semibold uppercase tracking-wide text-muted">Recent</div>
-                    {recentProjects.length === 0 ? (
-                      <p className="rounded-xl border border-divider/60 bg-white/80 px-3 py-2 text-xs text-muted shadow-sm">
-                        No workspaces yet. Create one to get started.
-                      </p>
-                    ) : (
-                      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-                        <ul className="grid min-w-0 grid-cols-1 gap-2">
-                          {recentProjects.map((project) => {
-                            const isConfirming = confirming.has(project.id);
-                            return (
-                              <li
-                                key={project.id}
-                                className="group w-full min-w-0 rounded-xl border border-divider/60 bg-white/90 px-3 py-2 shadow-sm transition hover:border-primary/50"
-                                title={project.name}
-                                data-project-id={project.id}
-                              >
-                                <div className="flex min-w-0 items-center justify-between gap-3">
-                                  <Link href={`/projects/${project.id}`} className="min-w-0 flex-1" title={project.name}>
-                                    <div className="truncate text-sm font-semibold text-slate-900" title={project.name}>
-                                      {project.name}
-                                    </div>
-                                    <div className="text-xs text-muted">
-                                      {dateFormatter.format(new Date(project.lastModified))}
-                                    </div>
-                                  </Link>
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      if (isConfirming) {
-                                        handleArchive(project.id);
-                                      } else {
-                                        setConfirming((prev) => new Set(prev).add(project.id));
-                                      }
-                                    }}
-                                    data-confirm-action="true"
-                                    className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
-                                      isConfirming
-                                        ? 'border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'
-                                        : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
-                                    }`}
-                                    aria-label={isConfirming ? 'Confirm archive' : 'Archive workspace'}
-                                    data-testid="archive-workspace"
-                                    data-project-id={project.id}
-                                  >
-                                    {isConfirming ? <CheckIcon className="h-4 w-4" /> : <ArchiveBoxArrowDownIcon className="h-4 w-4" />}
-                                  </button>
-                                </div>
-                              </li>
-                            );
-                          })}
-                        </ul>
-                      </div>
-                    )}
-                  </div>
-                  {archivedProjects.length > 0 ? (
-                    <div
-                      className={`flex min-h-0 flex-col gap-2 pt-2 ${
-                        showArchived ? 'h-[66%]' : ''
-                      }`}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => setShowArchived((prev) => !prev)}
-                        className="group flex items-center justify-between rounded-lg px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted transition hover:bg-primary/10 hover:text-slate-700"
-                        aria-expanded={showArchived}
-                      >
-                        <span>Archived</span>
-                        <span
-                          className={`text-muted transition-transform ${
-                            showArchived ? 'rotate-90' : ''
-                          }`}
-                        >
-                          <ChevronRightIcon className="h-3 w-3" />
-                        </span>
-                      </button>
-                      {showArchived ? (
+        renderRail={({ railCollapsed, toggleRail }) => (
+          <div className="mt-6 flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+            {!railCollapsed ? (
+              <>
+                <div className="rounded-full bg-white/90 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary shadow-sm">
+                  Workspaces
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+                    <div className={`flex min-h-0 flex-1 flex-col gap-2 ${archivedProjects.length > 0 ? 'border-b border-divider/60 pb-3' : ''}`}>
+                      <div className="text-xs font-semibold uppercase tracking-wide text-muted">Recent</div>
+                      {recentProjects.length === 0 ? (
+                        <p className="rounded-xl border border-divider/60 bg-white/80 px-3 py-2 text-xs text-muted shadow-sm">
+                          No workspaces yet. Create one to get started.
+                        </p>
+                      ) : (
                         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
                           <ul className="grid min-w-0 grid-cols-1 gap-2">
-                            {archivedProjects.map((project) => {
+                            {recentProjects.map((project) => {
                               const isConfirming = confirming.has(project.id);
                               return (
                                 <li
                                   key={project.id}
-                                  className="w-full min-w-0 rounded-xl border border-divider/60 bg-white/80 px-3 py-2 shadow-sm"
+                                  className="group w-full min-w-0 rounded-xl border border-divider/60 bg-white/90 px-3 py-2 shadow-sm transition hover:border-primary/50"
                                   title={project.name}
                                   data-project-id={project.id}
                                 >
-                                  <div className="flex min-w-0 flex-wrap items-center gap-2">
-                                    <span
-                                      className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900"
-                                      title={project.name}
-                                    >
-                                      {project.name}
-                                    </span>
+                                  <div className="flex min-w-0 items-center justify-between gap-3">
+                                    <Link href={`/projects/${project.id}`} className="min-w-0 flex-1" title={project.name}>
+                                      <div className="truncate text-sm font-semibold text-slate-900" title={project.name}>
+                                        {project.name}
+                                      </div>
+                                      <div className="text-xs text-muted">
+                                        {dateFormatter.format(new Date(project.lastModified))}
+                                      </div>
+                                    </Link>
                                     <button
                                       type="button"
                                       onClick={() => {
                                         if (isConfirming) {
-                                          handleUnarchive(project.id);
+                                          handleArchive(project.id);
                                         } else {
                                           setConfirming((prev) => new Set(prev).add(project.id));
                                         }
                                       }}
                                       data-confirm-action="true"
-                                      className={`ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
+                                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
                                         isConfirming
-                                          ? 'border border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                                          ? 'border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'
                                           : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
                                       }`}
-                                      aria-label={isConfirming ? 'Confirm unarchive' : 'Unarchive workspace'}
-                                      data-testid="unarchive-workspace"
+                                      aria-label={isConfirming ? 'Confirm archive' : 'Archive workspace'}
+                                      data-testid="archive-workspace"
                                       data-project-id={project.id}
                                     >
-                                      {isConfirming ? (
-                                        <CheckIcon className="h-4 w-4" />
-                                      ) : (
-                                        <BlueprintIcon icon="unarchive" className="h-4 w-4" />
-                                      )}
+                                      {isConfirming ? <CheckIcon className="h-4 w-4" /> : <ArchiveBoxArrowDownIcon className="h-4 w-4" />}
                                     </button>
                                   </div>
                                 </li>
@@ -262,21 +190,91 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                             })}
                           </ul>
                         </div>
-                      ) : null}
+                      )}
                     </div>
-                  ) : null}
-              </div>
+                    {archivedProjects.length > 0 ? (
+                      <div
+                        className={`flex min-h-0 flex-col gap-2 pt-2 ${
+                          showArchived ? 'h-[66%]' : ''
+                        }`}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => setShowArchived((prev) => !prev)}
+                          className="group flex items-center justify-between rounded-lg px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted transition hover:bg-primary/10 hover:text-slate-700"
+                          aria-expanded={showArchived}
+                        >
+                          <span>Archived</span>
+                          <span
+                            className={`text-muted transition-transform ${
+                              showArchived ? 'rotate-90' : ''
+                            }`}
+                          >
+                            <ChevronRightIcon className="h-3 w-3" />
+                          </span>
+                        </button>
+                        {showArchived ? (
+                          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                            <ul className="grid min-w-0 grid-cols-1 gap-2">
+                              {archivedProjects.map((project) => {
+                                const isConfirming = confirming.has(project.id);
+                                return (
+                                  <li
+                                    key={project.id}
+                                    className="w-full min-w-0 rounded-xl border border-divider/60 bg-white/80 px-3 py-2 shadow-sm"
+                                    title={project.name}
+                                    data-project-id={project.id}
+                                  >
+                                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                      <span
+                                        className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900"
+                                        title={project.name}
+                                      >
+                                        {project.name}
+                                      </span>
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          if (isConfirming) {
+                                            handleUnarchive(project.id);
+                                          } else {
+                                            setConfirming((prev) => new Set(prev).add(project.id));
+                                          }
+                                        }}
+                                        data-confirm-action="true"
+                                        className={`ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
+                                          isConfirming
+                                            ? 'border border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                                            : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
+                                        }`}
+                                        aria-label={isConfirming ? 'Confirm unarchive' : 'Unarchive workspace'}
+                                        data-testid="unarchive-workspace"
+                                        data-project-id={project.id}
+                                      >
+                                        {isConfirming ? (
+                                          <CheckIcon className="h-4 w-4" />
+                                        ) : (
+                                          <BlueprintIcon icon="unarchive" className="h-4 w-4" />
+                                        )}
+                                      </button>
+                                    </div>
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : null}
+                </div>
+              </>
+            ) : null}
 
-              <div className="mt-auto flex items-start pb-2">
-                <AuthRailStatus railCollapsed={railCollapsed} onRequestExpandRail={toggleRail} />
-              </div>
-            </div>
-          ) : (
             <div className="mt-auto flex items-start pb-2">
               <AuthRailStatus railCollapsed={railCollapsed} onRequestExpandRail={toggleRail} />
             </div>
-          )
-        }
+          </div>
+        )}
         renderMain={() => (
           <div className="flex-1 overflow-y-auto">
             <div className="mx-auto max-w-5xl px-6 py-12 space-y-8">

--- a/src/components/layout/RailShell.tsx
+++ b/src/components/layout/RailShell.tsx
@@ -20,31 +20,16 @@ export function RailShell({
       mainClassName="h-screen min-w-0 overflow-y-auto"
       renderRail={({ railCollapsed, toggleRail }) => (
         <div className="mt-6 flex flex-1 flex-col gap-6">
-          {railCollapsed ? (
-            <div className="mt-auto flex flex-col items-start gap-3 pb-2">
-              <AuthRailStatus railCollapsed={railCollapsed} onRequestExpandRail={toggleRail} />
-              <Link
-                href="/"
-                className="focus-ring inline-flex h-8 w-8 items-center justify-center rounded-full border border-divider/80 bg-white text-slate-800 shadow-sm transition hover:bg-primary/10"
-                aria-label="Back to home"
-              >
-                <HomeIcon className="h-4 w-4" />
-              </Link>
-            </div>
-          ) : (
-            <div className="mt-auto space-y-3 pb-2">
-              <div className="flex flex-col items-start gap-3">
-                <AuthRailStatus railCollapsed={railCollapsed} onRequestExpandRail={toggleRail} />
-                <Link
-                  href="/"
-                  className="focus-ring inline-flex h-8 w-8 items-center justify-center rounded-full border border-divider/80 bg-white text-slate-800 shadow-sm transition hover:bg-primary/10"
-                  aria-label="Back to home"
-                >
-                  <HomeIcon className="h-4 w-4" />
-                </Link>
-              </div>
-            </div>
-          )}
+          <div className="mt-auto flex flex-col items-start gap-3 pb-2">
+            <AuthRailStatus railCollapsed={railCollapsed} onRequestExpandRail={toggleRail} />
+            <Link
+              href="/"
+              className="focus-ring inline-flex h-8 w-8 items-center justify-center rounded-full border border-divider/80 bg-white text-slate-800 shadow-sm transition hover:bg-primary/10"
+              aria-label="Back to home"
+            >
+              <HomeIcon className="h-4 w-4" />
+            </Link>
+          </div>
         </div>
       )}
       renderMain={() => children}


### PR DESCRIPTION
Keep AuthRailStatus mounted across rail toggles to avoid repeated auth fetches and make branch pinning feel immediate with optimistic updates.

- refactor rail footers to prevent AuthRailStatus remounts
- add per-branch pin pending state + optimistic pin toggle
- adjust branch UI disabling/spinners accordingly
- mark rail auth + pin lag bugs as fixed