### PR TITLE
fix: align thinking/shared widths + supabase SSR cookies

### DIFF
--- a/PM_DOCS/BUGS.md
+++ b/PM_DOCS/BUGS.md
@@ -41,6 +41,8 @@
 [x] double check that we surface a clear user facing error if user tries a provider and has not entered an api token for that provider.
 [x] excess horizontal padding around the chat/graph container <div class="flex h-full min-h-0 min-w-0 flex-col gap-6 lg:flex-row lg:gap-0">
 [ ] gemini replies initially stream thinking content into chat view. Once complete, thinking is contained (corrrectly) in thinking box, and only reply content shows. This initial state is a bug.
+[x] default thinking bar width should meet the default (min) user message box (currently overlaps it) [Fixed - align assistant bubble/shared bar max width to leave user minimum width.]
+[x] default thinking bar and default shared message bar should be same width and flex the same on resize [Fixed - shared banner and assistant bubbles share the same max-width rule.]
 [x] toggling the rail fires an auth request [Fixed - keep AuthRailStatus mounted across rail toggles.]
 [x] pinning a branch instantly fires a request and triggers spinner - a bit laggy. Should copy our pattern from stars (seems nicer ui/ux) [Fixed - optimistic pin updates + per-button pending indicator.]
 

--- a/PM_DOCS/FRs.md
+++ b/PM_DOCS/FRs.md
@@ -32,7 +32,8 @@
 [x] when any message is added, the chat container should auto scroll to the bottom [Done - message list scrolls to bottom when `visibleNodes.length` increases]
 [x] Composer hint should fade to 10% opacity once the draft is non-empty. [Done - hint opacity drops when input has content]
 [x] Streaming autoscroll should stop when the user scrolls away, and resume when they return near the bottom. [Done - follow breaks on user scroll, resumes at threshold]
-[ ] thinking bar in the chat window should not extend beyond the user chat bubble max width; default width aligns with shared history bar (slightly wider than current); both shrink when squashed
+[x] thinking bar in the chat window should not extend beyond the user chat bubble max width; default width aligns with shared history bar (slightly wider than current); both shrink when squashed [Done - shared banner and assistant bubbles share a max-width cap that leaves room for the user minimum width.]
+[x] thinking box text should render markdown [Done - thinking traces render via ReactMarkdown + remark-gfm.]
 
 ### Branch
 

--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -133,7 +133,11 @@ const NodeBubble: FC<{
   const thinkingInProgress = isAssistantPending || (node.id === 'streaming' && messageText.length === 0);
   const showThinkingNote = isAssistant && showOpenAiThinkingNote && !hasThinking && !thinkingInProgress;
   const containerWidth = isAssistant ? 'w-full' : '';
-  const width = isUser ? 'min-w-[14rem] max-w-[82%]' : isAssistant ? 'w-full max-w-[85%]' : 'max-w-[82%]';
+  const width = isUser
+    ? 'min-w-[14rem] max-w-[82%]'
+    : isAssistant
+      ? 'w-full max-w-[85%] md:max-w-[calc(100%-14rem)]'
+      : 'max-w-[82%]';
   const base = `relative ${width} overflow-hidden rounded-2xl px-4 py-3 transition`;
   const palette = muted
     ? isUser
@@ -209,7 +213,9 @@ const NodeBubble: FC<{
               ) : null}
             </div>
             {showThinking && hasThinking ? (
-              <p className="mt-2 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700">{thinkingText}</p>
+              <div className="prose prose-sm prose-slate mt-2 max-w-none break-words">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{thinkingText}</ReactMarkdown>
+              </div>
             ) : null}
           </div>
         ) : null}
@@ -2228,7 +2234,7 @@ export function WorkspaceClient({
                 >
                   <div className="pointer-events-none absolute left-5 right-5 top-5 z-10 flex flex-wrap items-center gap-3">
                     {branchName !== trunkName && sharedCount > 0 ? (
-                      <div className="pointer-events-auto w-full md:w-3/5 md:ml-4">
+                      <div className="pointer-events-auto w-full md:ml-4 md:max-w-[calc(100%-12rem)]">
                         <div className="flex flex-wrap items-center gap-3 rounded-xl bg-[rgba(238,243,255,0.95)] px-4 py-3 text-sm text-slate-700 shadow-sm">
                           <div className="flex min-w-0 flex-1 items-center gap-2">
                             <span className="h-2 w-2 rounded-full bg-primary/80" />

--- a/src/server/supabase/server.ts
+++ b/src/server/supabase/server.ts
@@ -12,6 +12,16 @@ export function createSupabaseServerClient() {
     cookies: {
       getAll() {
         return cookieStore.getAll();
+      },
+      setAll(cookiesToSet: Array<{ name: string; value: string; options: CookieOptions }>) {
+        if (!('set' in cookieStore)) return;
+        for (const { name, value, options } of cookiesToSet) {
+          try {
+            cookieStore.set(name, value, options as CookieOptions);
+          } catch {
+            // ignore when called from read-only contexts
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
Align assistant thinking and shared bars while rendering thinking markdown, and ensure SSR Supabase clients can set cookies without warnings.

- cap shared banner width to leave room for user bubble minimum
- render thinking content via ReactMarkdown + remark-gfm
- add setAll handling to server Supabase client
- record bug and FR updates in PM docs