### PR TITLE
Block non-compliant password submissions

### DIFF
--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -16,6 +16,20 @@ function sanitizeRedirectTo(input: string | null): string | null {
   return input;
 }
 
+function validatePasswordPolicy(password: string): string | null {
+  if (password.length < 10) {
+    return 'Password must be at least 10 characters.';
+  }
+  const hasLower = /[a-z]/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+  const hasDigit = /\d/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+  if (!hasLower || !hasUpper || !hasDigit || !hasSymbol) {
+    return 'Password must include lowercase, uppercase, number, and symbol characters.';
+  }
+  return null;
+}
+
 export async function signInWithPassword(_prevState: AuthActionState, formData: FormData): Promise<AuthActionState> {
   const email = String(formData.get('email') ?? '').trim();
   const password = String(formData.get('password') ?? '');
@@ -23,6 +37,10 @@ export async function signInWithPassword(_prevState: AuthActionState, formData: 
 
   if (!email || !password) {
     return { error: 'Email and password are required.' };
+  }
+  const policyError = validatePasswordPolicy(password);
+  if (policyError) {
+    return { error: policyError };
   }
 
   try {
@@ -46,6 +64,10 @@ export async function signUpWithPassword(_prevState: AuthActionState, formData: 
 
   if (!email || !password) {
     return { error: 'Email and password are required.' };
+  }
+  const policyError = validatePasswordPolicy(password);
+  if (policyError) {
+    return { error: policyError };
   }
 
   try {


### PR DESCRIPTION
## Summary
- enforce the updated password policy (10+ chars with lowercase, uppercase, number, and symbol) in both sign-in and sign-up actions before calling Supabase
- add shared password policy helper and refresh auth action tests with compliant fixtures and character-class coverage

## Testing
- npm test -- tests/server/login-actions.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956609c7d8c832b9d8c34d4effa0cfc)