### PR TITLE
Add Cmd/Ctrl+Enter submission hotkeys across forms

### DIFF
--- a/app/admin/waitlist/ApproveEmailForm.tsx
+++ b/app/admin/waitlist/ApproveEmailForm.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useRef } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
 import type { approveEmailWithFeedbackAction } from './actions';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
 
 type ApproveState = Awaited<ReturnType<typeof approveEmailWithFeedbackAction>>;
 
@@ -31,6 +32,7 @@ function SubmitButton() {
 export function ApproveEmailForm({ action }: { action: typeof approveEmailWithFeedbackAction }) {
   const [state, formAction] = useFormState<ApproveState, FormData>(action, { ok: false, error: null, email: null });
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const handleCommandEnter = useCommandEnterSubmit();
 
   useEffect(() => {
     if (!state.ok) return;
@@ -40,7 +42,7 @@ export function ApproveEmailForm({ action }: { action: typeof approveEmailWithFe
   }, [state.ok]);
 
   return (
-    <form action={formAction} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+    <form onKeyDown={handleCommandEnter} action={formAction} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
       <label className="block flex-1">
         <span className="text-sm font-medium text-slate-800">Email</span>
         <input

--- a/app/admin/waitlist/page.tsx
+++ b/app/admin/waitlist/page.tsx
@@ -5,6 +5,7 @@ import { listAllowlistedEmails, listWaitlistRequests } from '@/src/server/waitli
 import { approveEmailAction, approveEmailWithFeedbackAction, removeAllowlistEmailAction } from './actions';
 import { ApproveEmailForm } from './ApproveEmailForm';
 import { AdminSubmitButton } from './AdminSubmitButton';
+import { CommandEnterForm } from '@/src/components/forms/CommandEnterForm';
 
 export default async function AdminWaitlistPage() {
   await requireAdminUser();
@@ -39,10 +40,10 @@ export default async function AdminWaitlistPage() {
                       {req.last_requested_at ? ` • Last: ${new Date(req.last_requested_at).toLocaleString()}` : ''}
                     </p>
                   </div>
-                  <form action={approveEmailAction}>
+                  <CommandEnterForm action={approveEmailAction}>
                     <input type="hidden" name="email" value={req.email} />
                     <AdminSubmitButton label="Approve" pendingLabel="Approving…" />
-                  </form>
+                  </CommandEnterForm>
                 </li>
               ))}
             </ul>
@@ -63,10 +64,10 @@ export default async function AdminWaitlistPage() {
                       {item.created_by ? `Approved by ${item.created_by}` : 'Approved'}
                     </p>
                   </div>
-                  <form action={removeAllowlistEmailAction}>
+                  <CommandEnterForm action={removeAllowlistEmailAction}>
                     <input type="hidden" name="email" value={item.email} />
                     <AdminSubmitButton label="Remove" pendingLabel="Removing…" variant="secondary" />
-                  </form>
+                  </CommandEnterForm>
                 </li>
               ))}
             </ul>

--- a/app/forgot-password/ForgotPasswordForm.tsx
+++ b/app/forgot-password/ForgotPasswordForm.tsx
@@ -5,6 +5,7 @@
 import { useFormState, useFormStatus } from 'react-dom';
 import Link from 'next/link';
 import { requestPasswordReset } from './actions';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
 
 const initialState = { error: null as string | null };
 
@@ -30,13 +31,14 @@ function SubmitButton() {
 
 export function ForgotPasswordForm({ redirectTo }: { redirectTo: string }) {
   const [state, action] = useFormState(requestPasswordReset, initialState);
+  const handleCommandEnter = useCommandEnterSubmit();
 
   return (
     <div className="mx-auto w-full max-w-sm rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
       <h1 className="text-xl font-semibold text-slate-900">Reset your password</h1>
       <p className="mt-2 text-sm text-slate-600">Enter your email and we’ll send a magic link to reset your password.</p>
 
-      <form action={action} className="mt-6 space-y-3">
+      <form onKeyDown={handleCommandEnter} action={action} className="mt-6 space-y-3">
         <input type="hidden" name="redirectTo" value={redirectTo} />
         <label className="block">
           <span className="text-sm font-medium text-slate-800">Email</span>

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useFormState, useFormStatus } from 'react-dom';
 import { useEffect, useMemo, useState } from 'react';
 import { signInWithPassword, signUpWithPassword } from './actions';
 import Link from 'next/link';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
 
 function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
@@ -42,6 +43,8 @@ export function LoginForm({
   const [signUpState, signUpAction] = useFormState(signUpWithPassword, initialState);
   const [mode, setMode] = useState<'signUp' | 'signIn'>('signUp');
   const [emailValue, setEmailValue] = useState(initialEmail ?? '');
+  const handleSignInCommandEnter = useCommandEnterSubmit();
+  const handleSignUpCommandEnter = useCommandEnterSubmit();
 
   useEffect(() => {
     if (window.location.hash === '#existing-user') {
@@ -60,7 +63,7 @@ export function LoginForm({
       <h1 className="text-xl font-semibold text-slate-900">{mode === 'signIn' ? 'Sign in' : 'Create an account'}</h1>
 
       {mode === 'signIn' ? (
-        <form action={signInAction} className="mt-6 space-y-3">
+        <form onKeyDown={handleSignInCommandEnter} action={signInAction} className="mt-6 space-y-3">
           <input type="hidden" name="redirectTo" value={redirectTo} />
           <label className="block">
             <span className="text-sm font-medium text-slate-800">Email</span>
@@ -98,7 +101,7 @@ export function LoginForm({
           </div>
         </form>
       ) : (
-        <form action={signUpAction} className="mt-6 space-y-3">
+        <form onKeyDown={handleSignUpCommandEnter} action={signUpAction} className="mt-6 space-y-3">
           <input type="hidden" name="redirectTo" value={redirectTo} />
           {waitlistEnforced ? (
             <p className="text-sm text-slate-600">

--- a/app/reset-password/ResetPasswordForm.tsx
+++ b/app/reset-password/ResetPasswordForm.tsx
@@ -5,6 +5,7 @@
 import { useFormState, useFormStatus } from 'react-dom';
 import Link from 'next/link';
 import { updatePassword } from './actions';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
 
 const initialState = { error: null as string | null };
 
@@ -30,13 +31,14 @@ function SubmitButton() {
 
 export function ResetPasswordForm({ redirectTo }: { redirectTo: string }) {
   const [state, action] = useFormState(updatePassword, initialState);
+  const handleCommandEnter = useCommandEnterSubmit();
 
   return (
     <div className="mx-auto w-full max-w-sm rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
       <h1 className="text-xl font-semibold text-slate-900">Set a new password</h1>
       <p className="mt-2 text-sm text-slate-600">Choose a new password for your account.</p>
 
-      <form action={action} className="mt-6 space-y-3">
+      <form onKeyDown={handleCommandEnter} action={action} className="mt-6 space-y-3">
         <input type="hidden" name="redirectTo" value={redirectTo} />
 
         <label className="block">

--- a/app/waitlist/page.tsx
+++ b/app/waitlist/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { APP_NAME } from '@/src/config/app';
 import { submitAccessCode, submitWaitlistRequest } from './actions';
 import { WaitlistSubmitButton } from './WaitlistSubmitButton';
+import { CommandEnterForm } from '@/src/components/forms/CommandEnterForm';
 
 function sanitizeRedirectTo(input: string | null): string {
   if (!input) return '/waitlist';
@@ -58,7 +59,7 @@ export default function WaitlistPage({
             </div>
           ) : null}
 
-          <form action={submitWaitlistRequest} className="space-y-3">
+          <CommandEnterForm action={submitWaitlistRequest} className="space-y-3">
             <input type="hidden" name="redirectTo" value={redirectTo} />
             <label className="block">
               <span className="text-sm font-medium text-slate-800">Email</span>
@@ -73,11 +74,11 @@ export default function WaitlistPage({
             </label>
 
             <WaitlistSubmitButton label="Request access" pendingLabel="Requesting…" />
-          </form>
+          </CommandEnterForm>
 
           <div className="border-t border-slate-200 pt-4">
             <p className="text-sm font-medium text-slate-800">Have an access code?</p>
-            <form action={submitAccessCode} className="mt-3 space-y-3">
+            <CommandEnterForm action={submitAccessCode} className="mt-3 space-y-3">
               <input type="hidden" name="redirectTo" value={redirectTo} />
               <label className="block">
                 <span className="text-sm font-medium text-slate-800">Email</span>
@@ -102,7 +103,7 @@ export default function WaitlistPage({
               </label>
 
               <WaitlistSubmitButton label="Apply access code" pendingLabel="Applying…" />
-            </form>
+            </CommandEnterForm>
           </div>
 
           <div className="flex flex-wrap items-center gap-3">

--- a/src/components/forms/CommandEnterForm.tsx
+++ b/src/components/forms/CommandEnterForm.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+'use client';
+
+import React from 'react';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
+
+type CommandEnterFormProps = React.FormHTMLAttributes<HTMLFormElement> & {
+  children: React.ReactNode;
+  enableCommandEnter?: boolean;
+};
+
+export function CommandEnterForm({
+  children,
+  enableCommandEnter = true,
+  onKeyDown,
+  ...formProps
+}: CommandEnterFormProps) {
+  const handleCommandEnter = useCommandEnterSubmit({ enabled: enableCommandEnter });
+
+  return (
+    <form
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+        handleCommandEnter(event);
+      }}
+      {...formProps}
+    >
+      {children}
+    </form>
+  );
+}

--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -5,6 +5,7 @@
 import React, { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import type { LLMProvider } from '@/src/shared/llmProvider';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
 
 interface ProviderOption {
   id: LLMProvider;
@@ -23,6 +24,7 @@ export function CreateProjectForm({ providerOptions, defaultProvider }: CreatePr
   const [isSubmitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
+  const handleCommandEnter = useCommandEnterSubmit();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -59,7 +61,7 @@ export function CreateProjectForm({ providerOptions, defaultProvider }: CreatePr
   };
 
   return (
-    <form onSubmit={handleSubmit} className="card-surface flex flex-col gap-4 p-6">
+    <form onKeyDown={handleCommandEnter} onSubmit={handleSubmit} className="card-surface flex flex-col gap-4 p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="text-sm font-medium text-primary">Create Workspace</p>

--- a/src/components/workspace/NewBranchFormCard.tsx
+++ b/src/components/workspace/NewBranchFormCard.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
 
+'use client';
+
 import React, { type FormEvent } from 'react';
+import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
 
 export function NewBranchFormCard({
   fromLabel,
@@ -28,9 +31,11 @@ export function NewBranchFormCard({
   containerClassName?: string;
 }) {
   const isDisabled = disabled || submitting;
+  const handleCommandEnter = useCommandEnterSubmit({ enabled: !isDisabled && Boolean(value.trim()) });
 
   return (
     <form
+      onKeyDown={handleCommandEnter}
       onSubmit={(event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         onSubmit();

--- a/src/hooks/useCommandEnterSubmit.ts
+++ b/src/hooks/useCommandEnterSubmit.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+'use client';
+
+import { useCallback } from 'react';
+
+type UseCommandEnterSubmitOptions = {
+  enabled?: boolean;
+};
+
+export function useCommandEnterSubmit({ enabled = true }: UseCommandEnterSubmitOptions = {}) {
+  return useCallback(
+    (event: React.KeyboardEvent<HTMLFormElement>) => {
+      if (!enabled) return;
+      if (event.key !== 'Enter') return;
+      if (!(event.metaKey || event.ctrlKey)) return;
+      if (event.altKey || event.shiftKey) return;
+
+      const form = event.currentTarget;
+      if (!form.checkValidity()) {
+        event.preventDefault();
+        form.reportValidity?.();
+        return;
+      }
+
+      event.preventDefault();
+      form.requestSubmit();
+    },
+    [enabled]
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable command-enter submission hook and wrapper form component
- enable cmd/ctrl+enter submission on auth, waitlist, admin, project creation, and branching forms
- guard hotkey-triggered submissions behind native form validity checks

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69566fbb4418832ba8e5e9ec1f9eab6e)