### PR TITLE
fix: prevent branch split on transient streaming nodes

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -116,6 +116,7 @@ const NodeBubble: FC<{
 }) => {
   const isUser = node.type === 'message' && node.role === 'user';
   const isAssistantPending = node.type === 'message' && node.role === 'assistant' && node.id === 'assistant-pending';
+  const isTransientNode = node.id === 'streaming' || node.id === 'assistant-pending' || node.id === 'optimistic-user';
   const messageText = getNodeText(node);
   const thinkingText = getNodeThinkingText(node);
   const canCopy = node.type === 'message' && messageText.length > 0;
@@ -394,6 +395,7 @@ const NodeBubble: FC<{
           ) : null}
           {node.type === 'message' &&
           onEdit &&
+          !isTransientNode &&
           (node.role === 'user' || node.role === 'assistant' || features.uiEditAnyMessage) ? (
             <button
               type="button"


### PR DESCRIPTION
fix: prevent branch split on transient streaming nodes

Avoids creating branches from transient chat placeholders during streaming so the PG UUID lookup never receives invalid node ids.

- suppress edit/branch action on streaming, pending, and optimistic nodes