### PR TITLE
chore: enforce local PG RPC registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "tsc --noEmit && node scripts/check-supabase-usage.js",
+    "lint": "tsc --noEmit && node scripts/check-supabase-usage.js && node scripts/check-local-pg-rpcs.js",
     "local:pg:bootstrap": "node --loader ts-node/esm scripts/local-pg-bootstrap.ts",
     "desktop:dev": "DESKTOP_NEXT_DEV=1 electron-forge start",
     "desktop:package": "node scripts/desktop-package.js package",

--- a/scripts/check-local-pg-rpcs.js
+++ b/scripts/check-local-pg-rpcs.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const RPC_CONFIG_FILE = path.join(ROOT, 'src/store/pg/localAdapter.ts');
+const RPC_SCAN_ROOT = path.join(ROOT, 'src/store/pg');
+const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+async function gatherFiles(entry) {
+  const stat = await fs.stat(entry);
+  if (stat.isFile()) {
+    return [entry];
+  }
+  if (!stat.isDirectory()) return [];
+  const entries = await fs.readdir(entry);
+  const results = [];
+  for (const name of entries) {
+    results.push(...(await gatherFiles(path.join(entry, name))));
+  }
+  return results;
+}
+
+function isTargetFile(filePath) {
+  return TARGET_EXTENSIONS.has(path.extname(filePath));
+}
+
+function extractRpcConfigNames(contents) {
+  const names = new Set();
+  const regex = /\b(rt_[a-z0-9_]+)\s*:/g;
+  let match;
+  while ((match = regex.exec(contents)) !== null) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+function extractRpcCalls(contents) {
+  const names = new Set();
+  const regex = /\b(?:adminRpc|rpc)\(\s*['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = regex.exec(contents)) !== null) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+async function main() {
+  const configContents = await fs.readFile(RPC_CONFIG_FILE, 'utf8');
+  const configNames = extractRpcConfigNames(configContents);
+
+  const files = (await gatherFiles(RPC_SCAN_ROOT)).filter(isTargetFile);
+  const rpcCalls = new Set();
+  for (const filePath of files) {
+    const contents = await fs.readFile(filePath, 'utf8');
+    for (const name of extractRpcCalls(contents)) {
+      rpcCalls.add(name);
+    }
+  }
+
+  const missing = [...rpcCalls].filter((name) => !configNames.has(name));
+  if (missing.length > 0) {
+    console.error('Local PG adapter RPC config missing for:');
+    for (const name of missing.sort()) {
+      console.error(`- ${name}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error('Local PG RPC config check failed:', error);
+  process.exit(1);
+});

--- a/src/store/pg/localAdapter.ts
+++ b/src/store/pg/localAdapter.ts
@@ -57,6 +57,19 @@ const RPC_CONFIG: Record<string, { params: string[]; returnType: RpcReturnType }
     ],
     returnType: 'set'
   },
+  rt_create_ref_from_node_v2: {
+    params: [
+      'p_project_id',
+      'p_source_ref_id',
+      'p_new_ref_name',
+      'p_node_id',
+      'p_provider',
+      'p_model',
+      'p_previous_response_id',
+      'p_lock_timeout_ms'
+    ],
+    returnType: 'set'
+  },
   rt_create_ref_from_ref_v2: {
     params: [
       'p_project_id',


### PR DESCRIPTION
Add a lint guard that ensures all pg rpc/adminRpc calls are registered in the local adapter, and register the new assistant-branch RPC. This prevents local/dev pg mode from failing due to missing RPC config.

- add scripts/check-local-pg-rpcs.js and hook it into lint

- register rt_create_ref_from_node_v2 in the local PG adapter