### PR TITLE
fix: scope question branch UI to highlighted assistant

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -671,11 +671,19 @@ export function WorkspaceClient({
         setShowNewBranchPopover(true);
         return;
       }
-      if (showNewBranchPopover) {
+      if (showNewBranchPopover && branchSplitNodeId === node.id && branchPopoverMode === 'standard') {
         setShowNewBranchPopover(false);
         resetBranchQuestionState();
         return;
       }
+      setShowNewBranchPopover(false);
+      resetBranchQuestionState();
+      setBranchActionError(null);
+      setNewBranchName('');
+      setBranchSplitNodeId(node.id);
+      setBranchPopoverMode('standard');
+      setShowNewBranchPopover(true);
+      return;
     }
     if (showNewBranchPopover) {
       setShowNewBranchPopover(false);


### PR DESCRIPTION
This refines the branch question flow so only highlighted assistant messages show the question-state branch button and the highlight/question UI appears only when invoked. Regular branch actions remain unchanged.

- detect assistant message selection to enable question state

- swap branch button icon/style when highlight is active

- gate highlight/question/checkbox UI behind question mode