### PR TITLE
Add copy controls to assistant markdown code blocks

### DIFF
--- a/src/components/workspace/MarkdownWithCopy.tsx
+++ b/src/components/workspace/MarkdownWithCopy.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import React, { useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Components } from 'react-markdown';
+import { CheckIcon, Square2StackIcon } from './HeroIcons';
+import { copyTextToClipboard } from './clipboard';
+
+type MarkdownWithCopyProps = {
+  content: string;
+  className?: string;
+};
+
+type CodeProps = {
+  inline?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+};
+
+type PreProps = {
+  children?: React.ReactNode;
+};
+
+const CodeBlock = ({ inline, className, children }: CodeProps) => {
+  const [copied, setCopied] = useState(false);
+
+  if (inline) {
+    return <code className={className}>{children}</code>;
+  }
+
+  const text = String(children ?? '').replace(/\n$/, '');
+
+  const handleCopy = async () => {
+    await copyTextToClipboard(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <div className="group relative mt-4">
+      <pre className="overflow-x-auto rounded-xl bg-slate-900/90 p-4 text-sm leading-6 text-slate-50 shadow-sm">
+        <code className={className}>{children}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={() => {
+          void handleCopy();
+        }}
+        aria-label={copied ? 'Code copied' : 'Copy code block'}
+        className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-800/80 px-3 py-1 text-xs font-semibold text-slate-100 opacity-100 transition hover:bg-slate-700/90 focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-2 focus:ring-offset-slate-900"
+      >
+        {copied ? (
+          <>
+            <CheckIcon className="h-4 w-4 text-emerald-300" />
+            <span>Copied</span>
+          </>
+        ) : (
+          <>
+            <Square2StackIcon className="h-4 w-4 text-slate-200" />
+            <span>Copy</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export const MarkdownWithCopy = ({ content, className }: MarkdownWithCopyProps) => {
+  const components = useMemo<Components>(
+    () => ({
+      code: (props) => <CodeBlock {...props} />,
+      pre: ({ children }: PreProps) => <>{children}</>
+    }),
+    []
+  );
+
+  return (
+    <ReactMarkdown className={className} components={components} remarkPlugins={[remarkGfm]}>
+      {content}
+    </ReactMarkdown>
+  );
+};

--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -41,6 +41,8 @@ import {
   Square2StackIcon,
   XMarkIcon
 } from './HeroIcons';
+import { MarkdownWithCopy } from './MarkdownWithCopy';
+import { copyTextToClipboard } from './clipboard';
 
 const fetchJson = async <T,>(url: string): Promise<T> => {
   const res = await fetch(url);
@@ -149,29 +151,6 @@ const NodeBubble: FC<{
     : 'bg-white text-slate-900';
   const align = isUser ? 'ml-auto items-end' : 'mr-auto items-start';
 
-  const copyToClipboard = async (text: string) => {
-    if (typeof navigator === 'undefined') return;
-    try {
-      await navigator.clipboard.writeText(text);
-      return;
-    } catch {
-      // ignore and fall back
-    }
-    try {
-      const textarea = document.createElement('textarea');
-      textarea.value = text;
-      textarea.setAttribute('readonly', '');
-      textarea.style.position = 'fixed';
-      textarea.style.left = '-9999px';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-    } catch {
-      // ignore
-    }
-  };
-
   useEffect(() => {
     return () => {
       if (copyFeedbackTimeoutRef.current) {
@@ -223,7 +202,7 @@ const NodeBubble: FC<{
         {node.type === 'message' && messageText ? (
           isAssistant ? (
             <div className="prose prose-sm prose-slate mt-2 max-w-none break-words">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{messageText}</ReactMarkdown>
+              <MarkdownWithCopy content={messageText} />
             </div>
           ) : (
             <p className="mt-2 whitespace-pre-line break-words text-sm leading-relaxed text-slate-800">{messageText}</p>
@@ -375,7 +354,7 @@ const NodeBubble: FC<{
               type="button"
               onClick={() => {
                 void (async () => {
-                  await copyToClipboard(messageText);
+                  await copyTextToClipboard(messageText);
                   setCopyFeedback(true);
                   if (copyFeedbackTimeoutRef.current) {
                     clearTimeout(copyFeedbackTimeoutRef.current);
@@ -661,28 +640,6 @@ export function WorkspaceClient({
     }
   };
 
-  const copyTextToClipboard = async (text: string) => {
-    if (typeof navigator === 'undefined') return;
-    try {
-      await navigator.clipboard.writeText(text);
-      return;
-    } catch {
-      // ignore and fall back
-    }
-    try {
-      const textarea = document.createElement('textarea');
-      textarea.value = text;
-      textarea.setAttribute('readonly', '');
-      textarea.style.position = 'fixed';
-      textarea.style.left = '-9999px';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-    } catch {
-      // ignore
-    }
-  };
   const { nodes, artefact, artefactMeta, isLoading, error, mutateHistory, mutateArtefact } = useProjectData(project.id, {
     ref: branchName
   });

--- a/src/components/workspace/clipboard.ts
+++ b/src/components/workspace/clipboard.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+export const copyTextToClipboard = async (text: string) => {
+  if (typeof navigator === 'undefined') return;
+  try {
+    await navigator.clipboard.writeText(text);
+    return;
+  } catch {
+    // ignore and fall back
+  }
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  } catch {
+    // ignore
+  }
+};

--- a/tests/client/MarkdownWithCopy.test.tsx
+++ b/tests/client/MarkdownWithCopy.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/src/components/workspace/clipboard', () => ({
+  copyTextToClipboard: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { copyTextToClipboard } from '@/src/components/workspace/clipboard';
+import { MarkdownWithCopy } from '@/src/components/workspace/MarkdownWithCopy';
+
+const copyTextToClipboardMock = vi.mocked(copyTextToClipboard);
+
+describe('MarkdownWithCopy', () => {
+  beforeEach(() => {
+    copyTextToClipboardMock.mockClear();
+  });
+
+  it('renders a copy control for each fenced code block', async () => {
+    const user = userEvent.setup();
+    render(
+      <div className="prose prose-sm prose-slate">
+        <MarkdownWithCopy
+          content={`Here is some text.\n\n\`\`\`js\nconsole.log('alpha');\n\`\`\`\n\n\`\`\`ts\nconst beta = 2;\n\`\`\``}
+        />
+      </div>
+    );
+
+    const buttons = screen.getAllByRole('button', { name: /copy code block/i });
+    expect(buttons).toHaveLength(2);
+
+    await user.click(buttons[0]!);
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith("console.log('alpha');");
+    expect(buttons[0]).toHaveTextContent(/copied/i);
+    expect(buttons[1]).toHaveTextContent(/copy/i);
+
+    await user.click(buttons[1]!);
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith('const beta = 2;');
+  });
+});


### PR DESCRIPTION
## Summary
- create a MarkdownWithCopy wrapper around ReactMarkdown that adds per-code-block copy controls with success feedback
- reuse a shared clipboard helper in WorkspaceClient and wire assistant messages to the new renderer
- add a client test to confirm multiple fenced code blocks each expose independent copy buttons

## Testing
- npm test -- MarkdownWithCopy

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f6aea3c0832b989c036e192fbbd7)