### PR TITLE
Handle question branch creation without blocking the UI

### DIFF
--- a/src/components/workspace/NewBranchFormCard.tsx
+++ b/src/components/workspace/NewBranchFormCard.tsx
@@ -10,6 +10,7 @@ export function NewBranchFormCard({
   value,
   onValueChange,
   onSubmit,
+  children,
   providerSelector,
   disabled = false,
   submitting = false,
@@ -25,6 +26,7 @@ export function NewBranchFormCard({
   value: string;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
+  children?: React.ReactNode;
   providerSelector?: React.ReactNode;
   disabled?: boolean;
   submitting?: boolean;
@@ -85,6 +87,7 @@ export function NewBranchFormCard({
         </button>
       </div>
       {providerSelector ? <div>{providerSelector}</div> : null}
+      {children ? <div className="space-y-3">{children}</div> : null}
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
     </form>
   );

--- a/src/hooks/useCommandEnterSubmit.ts
+++ b/src/hooks/useCommandEnterSubmit.ts
@@ -3,6 +3,7 @@
 'use client';
 
 import { useCallback } from 'react';
+import type React from 'react';
 
 type UseCommandEnterSubmitOptions = {
   enabled?: boolean;
@@ -10,13 +11,17 @@ type UseCommandEnterSubmitOptions = {
 
 export function useCommandEnterSubmit({ enabled = true }: UseCommandEnterSubmitOptions = {}) {
   return useCallback(
-    (event: React.KeyboardEvent<HTMLFormElement>) => {
+    (event: React.KeyboardEvent<HTMLElement>) => {
       if (!enabled) return;
       if (event.key !== 'Enter') return;
       if (!(event.metaKey || event.ctrlKey)) return;
       if (event.altKey || event.shiftKey) return;
 
-      const form = event.currentTarget;
+      const target = event.currentTarget as HTMLElement | null;
+      const form = target?.closest('form');
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
       if (!form.checkValidity()) {
         event.preventDefault();
         form.reportValidity?.();


### PR DESCRIPTION
## Summary
- allow question branch creation and question submission to run without locking the current branch when the user stays on the same thread
- embed question/highlight inputs inside the branch form so cmd+Enter submission and validation work from any focused field
- broaden the cmd+Enter helper to submit from any descendant element and keep required field validation intact

## Testing
- npm run test *(fails on the full suite: existing failures in tests/git/integration.test.ts and tests/server/llm-resolve-provider.test.ts during the long run)*
- npm run test -- tests/git/integration.test.ts tests/server/llm-resolve-provider.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a19974f38832b9460481b19c29b1c)