### PR TITLE
Add branch visibility toggle and hide branches from graph views

### DIFF
--- a/app/api/projects/[id]/branches/[refId]/hide/route.ts
+++ b/app/api/projects/[id]/branches/[refId]/hide/route.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { handleRouteError, badRequest, notFound } from '@/src/server/http';
+import { withProjectLock } from '@/src/server/locks';
+import { requireUser } from '@/src/server/auth';
+import { requireProjectAccess } from '@/src/server/authz';
+import { getStoreConfig } from '@/src/server/storeConfig';
+
+interface RouteContext {
+  params: { id: string; refId: string };
+}
+
+export async function POST(_request: Request, { params }: RouteContext) {
+  try {
+    await requireUser();
+    const store = getStoreConfig();
+    await requireProjectAccess({ id: params.id });
+
+    if (store.mode === 'pg') {
+      return await withProjectLock(params.id, async () => {
+        const { rtSetRefVisibilityShadowV1 } = await import('@/src/store/pg/branches');
+        const { rtGetCurrentRefShadowV2 } = await import('@/src/store/pg/prefs');
+        const { rtListRefsShadowV2 } = await import('@/src/store/pg/reads');
+
+        if (!params.refId?.trim()) {
+          throw badRequest('Branch id is required');
+        }
+
+        await rtSetRefVisibilityShadowV1({ projectId: params.id, refId: params.refId, isHidden: true });
+        const current = await rtGetCurrentRefShadowV2({ projectId: params.id, defaultRefName: 'main' });
+        const branches = await rtListRefsShadowV2({ projectId: params.id });
+        return Response.json({
+          branchName: current.refName,
+          branchId: current.refId,
+          branches
+        });
+      });
+    }
+
+    const { getProject } = await import('@git/projects');
+    const { setBranchHidden, listBranches } = await import('@git/branches');
+    const { getCurrentBranchName } = await import('@git/utils');
+
+    const project = await getProject(params.id);
+    if (!project) {
+      throw notFound('Project not found');
+    }
+
+    return await withProjectLock(project.id, async () => {
+      await setBranchHidden(project.id, params.refId, true);
+      const branches = await listBranches(project.id);
+      const currentBranch = await getCurrentBranchName(project.id);
+      return Response.json({ branchName: currentBranch, branches });
+    });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  try {
+    await requireUser();
+    const store = getStoreConfig();
+    await requireProjectAccess({ id: params.id });
+
+    if (store.mode === 'pg') {
+      return await withProjectLock(params.id, async () => {
+        const { rtSetRefVisibilityShadowV1 } = await import('@/src/store/pg/branches');
+        const { rtGetCurrentRefShadowV2 } = await import('@/src/store/pg/prefs');
+        const { rtListRefsShadowV2 } = await import('@/src/store/pg/reads');
+
+        if (!params.refId?.trim()) {
+          throw badRequest('Branch id is required');
+        }
+
+        await rtSetRefVisibilityShadowV1({ projectId: params.id, refId: params.refId, isHidden: false });
+        const current = await rtGetCurrentRefShadowV2({ projectId: params.id, defaultRefName: 'main' });
+        const branches = await rtListRefsShadowV2({ projectId: params.id });
+        return Response.json({
+          branchName: current.refName,
+          branchId: current.refId,
+          branches
+        });
+      });
+    }
+
+    const { getProject } = await import('@git/projects');
+    const { setBranchHidden, listBranches } = await import('@git/branches');
+    const { getCurrentBranchName } = await import('@git/utils');
+
+    const project = await getProject(params.id);
+    if (!project) {
+      throw notFound('Project not found');
+    }
+
+    return await withProjectLock(project.id, async () => {
+      await setBranchHidden(project.id, params.refId, false);
+      const branches = await listBranches(project.id);
+      const currentBranch = await getCurrentBranchName(project.id);
+      return Response.json({ branchName: currentBranch, branches });
+    });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/app/api/projects/[id]/graph/route.ts
+++ b/app/api/projects/[id]/graph/route.ts
@@ -36,12 +36,13 @@ export async function GET(_request: Request, { params }: RouteContext) {
       const { rtGetCurrentRefShadowV2 } = await import('@/src/store/pg/prefs');
 
       const branches = await rtListRefsShadowV2({ projectId: params.id });
-      const trunkName = branches.find((b) => b.isTrunk)?.name ?? INITIAL_BRANCH;
+      const visibleBranches = branches.filter((branch) => !branch.isHidden);
+      const trunkName = visibleBranches.find((b) => b.isTrunk)?.name ?? INITIAL_BRANCH;
       const currentBranch = (await rtGetCurrentRefShadowV2({ projectId: params.id, defaultRefName: trunkName })).refName;
 
       const [branchHistoriesEntries, starredNodeIds] = await Promise.all([
         Promise.all(
-          branches.map(async (branch) => {
+          visibleBranches.map(async (branch) => {
             if (!branch.id) {
               return [branch.name, [] as NodeRecord[]] as [string, NodeRecord[]];
             }
@@ -78,12 +79,13 @@ export async function GET(_request: Request, { params }: RouteContext) {
       throw notFound('Project not found');
     }
     const branches = await listBranches(project.id);
-    const trunkName = branches.find((b) => b.isTrunk)?.name ?? INITIAL_BRANCH;
+    const visibleBranches = branches.filter((branch) => !branch.isHidden);
+    const trunkName = visibleBranches.find((b) => b.isTrunk)?.name ?? INITIAL_BRANCH;
     const currentBranch = await getCurrentBranchName(project.id).catch(() => trunkName);
 
     const [branchHistoriesEntries, starredNodeIds] = await Promise.all([
       Promise.all(
-        branches.map(async (branch) => {
+        visibleBranches.map(async (branch) => {
           const nodes = await readNodesFromRef(project.id, branch.name);
           const visible = nodes.filter((node) => !isHiddenMessage(node));
           return [branch.name, capNodesForGraph(visible, MAX_PER_BRANCH)] as [string, NodeRecord[]];

--- a/src/git/types.ts
+++ b/src/git/types.ts
@@ -92,6 +92,7 @@ export interface ProjectMetadata {
   createdAt: string;
   branchName?: string;
   pinnedBranchName?: string;
+  hiddenBranchNames?: string[];
 }
 
 export interface BranchSummary {
@@ -101,6 +102,7 @@ export interface BranchSummary {
   nodeCount: number;
   isTrunk: boolean;
   isPinned?: boolean;
+  isHidden?: boolean;
   provider?: LLMProvider;
   model?: string;
 }

--- a/src/store/pg/branches.ts
+++ b/src/store/pg/branches.ts
@@ -163,6 +163,24 @@ export async function rtClearPinnedRefShadowV2(input: { projectId: string }): Pr
   }
 }
 
+export async function rtSetRefVisibilityShadowV1(input: {
+  projectId: string;
+  refId: string;
+  isHidden: boolean;
+  lockTimeoutMs?: number;
+}): Promise<void> {
+  const { rpc } = getPgStoreAdapter();
+  const { error } = await rpc('rt_set_ref_visibility_v1', {
+    p_project_id: input.projectId,
+    p_ref_id: input.refId,
+    p_is_hidden: input.isHidden,
+    p_lock_timeout_ms: input.lockTimeoutMs ?? 3000
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
 export async function rtGetPinnedRefShadowV2(input: {
   projectId: string;
 }): Promise<{ refId: string | null; refName: string | null }> {

--- a/src/store/pg/localAdapter.ts
+++ b/src/store/pg/localAdapter.ts
@@ -22,6 +22,7 @@ const RPC_CONFIG: Record<string, { params: string[]; returnType: RpcReturnType }
   rt_set_pinned_ref_v2: { params: ['p_project_id', 'p_ref_id'], returnType: 'void' },
   rt_clear_pinned_ref_v2: { params: ['p_project_id'], returnType: 'void' },
   rt_get_pinned_ref_v2: { params: ['p_project_id'], returnType: 'set' },
+  rt_set_ref_visibility_v1: { params: ['p_project_id', 'p_ref_id', 'p_is_hidden', 'p_lock_timeout_ms'], returnType: 'void' },
   rt_list_projects_v1: { params: [], returnType: 'set' },
   rt_get_project_v1: { params: ['p_project_id'], returnType: 'set' },
   rt_list_project_member_ids_v1: { params: ['p_user_id'], returnType: 'set' },

--- a/src/store/pg/reads.ts
+++ b/src/store/pg/reads.ts
@@ -9,6 +9,7 @@ export interface PgBranchSummary {
   nodeCount: number;
   isTrunk: boolean;
   isPinned: boolean;
+  isHidden: boolean;
   provider?: string;
   model?: string;
 }
@@ -153,6 +154,7 @@ export async function rtListRefsShadowV2(input: { projectId: string }): Promise<
     nodeCount: Number(row.node_count ?? 0),
     isTrunk: Boolean(row.is_trunk),
     isPinned: Boolean(row.is_pinned),
+    isHidden: Boolean(row.is_hidden),
     provider: row.provider ? String(row.provider) : undefined,
     model: row.model ? String(row.model) : undefined
   }));

--- a/supabase/migrations/20260104110321_ref_visibility.sql
+++ b/supabase/migrations/20260104110321_ref_visibility.sql
@@ -1,0 +1,108 @@
+-- Add branch visibility flag and RPC to toggle it, and surface it via rt_list_refs_v2.
+
+alter table public.refs
+  add column if not exists is_hidden boolean not null default false;
+
+create or replace function public.rt_set_ref_visibility_v1(
+  p_project_id uuid,
+  p_ref_id uuid,
+  p_is_hidden boolean,
+  p_lock_timeout_ms integer default 3000
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+  if not public.rt_is_project_member(p_project_id) then
+    raise exception 'Not authorized';
+  end if;
+  if p_ref_id is null then
+    raise exception 'Branch id is required';
+  end if;
+
+  perform set_config('lock_timeout', concat(coalesce(p_lock_timeout_ms, 3000), 'ms'), true);
+
+  if exists (
+    select 1
+    from public.refs r
+    where r.project_id = p_project_id
+      and r.id = p_ref_id
+      and r.name = 'main'
+  ) then
+    raise exception 'Cannot hide trunk branch';
+  end if;
+
+  update public.refs
+  set is_hidden = coalesce(p_is_hidden, false),
+      updated_at = now()
+  where project_id = p_project_id
+    and id = p_ref_id;
+
+  if not found then
+    raise exception 'Branch not found';
+  end if;
+end;
+$$;
+
+revoke all on function public.rt_set_ref_visibility_v1(uuid, uuid, boolean, integer) from public;
+grant execute on function public.rt_set_ref_visibility_v1(uuid, uuid, boolean, integer) to authenticated;
+
+drop function if exists public.rt_list_refs_v2(uuid);
+
+create function public.rt_list_refs_v2(
+  p_project_id uuid
+)
+returns table (
+  id uuid,
+  name text,
+  head_commit text,
+  node_count bigint,
+  is_trunk boolean,
+  is_pinned boolean,
+  is_hidden boolean,
+  provider text,
+  model text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+  if not public.rt_is_project_member(p_project_id) then
+    raise exception 'Not authorized';
+  end if;
+
+  return query
+  select
+    r.id,
+    r.name,
+    coalesce(r.tip_commit_id::text, '') as head_commit,
+    coalesce(mx.max_ordinal + 1, 0)::bigint as node_count,
+    (r.name = 'main') as is_trunk,
+    (r.id = p.pinned_ref_id) as is_pinned,
+    coalesce(r.is_hidden, false) as is_hidden,
+    r.provider,
+    r.model
+  from public.refs r
+  left join (
+    select co.ref_id, max(co.ordinal) as max_ordinal
+    from public.commit_order co
+    where co.project_id = p_project_id
+    group by co.ref_id
+  ) mx on mx.ref_id = r.id
+  left join public.projects p on p.id = p_project_id
+  where r.project_id = p_project_id
+  order by coalesce(r.is_hidden, false) asc, (r.id = p.pinned_ref_id) desc, (r.name = 'main') desc, r.updated_at desc, r.name asc;
+end;
+$$;
+
+revoke all on function public.rt_list_refs_v2(uuid) from public;
+grant execute on function public.rt_list_refs_v2(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add a branch visibility flag in Supabase and git metadata plus a hide/unhide API for branches
- update the workspace rail with an eye toggle, sort hidden branches last, and keep hidden branches out of graph data/legend
- cover the new visibility behavior with a dedicated migration and WorkspaceClient tests

## Testing
- npm test -- tests/client/WorkspaceClient.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a46bb6cf0832bad6da6e720444fcd)