### PR TITLE
fix: escape highlight blocks in chat prompts

### DIFF
--- a/app/api/projects/[id]/chat/route.ts
+++ b/app/api/projects/[id]/chat/route.ts
@@ -61,6 +61,12 @@ function buildCanvasDiffMessage(diff: string): string {
   ].join('\n');
 }
 
+function formatHighlightBlock(highlight: string): string {
+  const fence = '```';
+  const escaped = highlight.replaceAll(fence, '\\`\\`\\`');
+  return `${fence}text\n${escaped}\n${fence}`;
+}
+
 function buildUserMessage(input: { message?: string | null; question?: string | null; highlight?: string | null }): string {
   const highlight = input.highlight?.trim() ?? '';
   const question = input.question?.trim() ?? '';
@@ -69,7 +75,7 @@ function buildUserMessage(input: { message?: string | null; question?: string | 
   const parts: string[] = [];
 
   if (highlight) {
-    parts.push('Highlighted passage:', `"""${highlight}"""`);
+    parts.push('Highlighted passage:', formatHighlightBlock(highlight));
   }
 
   if (question) {


### PR DESCRIPTION
Ensure highlight blocks use fenced code and escape backticks to avoid malformed prompt formatting.
- Add helper to format highlight blocks safely
- Replace triple-quote wrapper with fenced block