### PR TITLE
Follow-up: remove legacy branch popover

### DIFF
--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -150,10 +150,10 @@ test('workspace smoke flow', async ({ page }) => {
   await saveCanvas(page, trunkCanvas);
 
   await page.getByTestId('branch-new-button').click();
-  await expect(page.getByTestId('branch-popover')).toBeVisible();
-  await page.getByTestId('branch-provider-select-popover').selectOption('gemini');
-  await page.getByTestId('branch-form-popover-input').fill(regularBranch);
-  await page.getByTestId('branch-form-popover-submit').click();
+  await expect(page.getByTestId('branch-modal')).toBeVisible();
+  await page.getByTestId('branch-provider-select').selectOption('gemini');
+  await page.getByTestId('branch-form-modal-input').fill(regularBranch);
+  await page.getByTestId('branch-form-modal-submit').click();
   await expect(page.locator(`[data-testid="branch-switch"][data-branch-name="${regularBranch}"]`)).toBeVisible();
   await expectActiveBranch(page, regularBranch);
 
@@ -171,10 +171,10 @@ test('workspace smoke flow', async ({ page }) => {
   await waitForAssistantResponse(page, geminiCount);
 
   await page.getByRole('button', { name: 'Create branch from message' }).last().click();
-  await expect(page.getByTestId('branch-popover')).toBeVisible();
-  await page.getByTestId('branch-provider-select-popover').selectOption('anthropic');
-  await page.getByTestId('branch-form-popover-input').fill(assistantBranch);
-  await page.getByTestId('branch-form-popover-submit').click();
+  await expect(page.getByTestId('branch-modal')).toBeVisible();
+  await page.getByTestId('branch-provider-select').selectOption('anthropic');
+  await page.getByTestId('branch-form-modal-input').fill(assistantBranch);
+  await page.getByTestId('branch-form-modal-submit').click();
   await expect(page.locator(`[data-testid="branch-switch"][data-branch-name="${assistantBranch}"]`)).toBeVisible();
   await expectActiveBranch(page, assistantBranch);
 


### PR DESCRIPTION
### Motivation
- The codebase had two different branch-creation paths (popover vs centered modal) causing inconsistent UX and background popover activation.
- The goal is to converge all branch entry points to a single centered modal and remove the leftover popover variant.
- Simplify modal state and ensure branch highlighting and question flows remain correct when branching from assistant messages.
- Update end-to-end test selectors to reflect the new modal-based UI.

### Description
- Removed the popover-based branch UI and unified all branch triggers to open the centered modal by replacing popover state/refs with modal equivalents in `src/components/workspace/WorkspaceClient.tsx`.
- Renamed state and refs (`showNewBranchPopover` -> `showNewBranchModal`, `branchPopoverMode` -> `branchModalMode`, `newBranchPopoverRef` -> `newBranchModalRef`) and updated all usages to keep branch highlighting tied to the modal flow.
- Dropped the popover-specific pointer handlers and the `data-branch-trigger` attribute on assistant message buttons so triggers route to the shared modal instead.
- Updated Playwright selectors and test IDs in `tests/e2e/smoke.spec.ts` (e.g., `branch-popover` -> `branch-modal`, `branch-form-popover` -> `branch-form-modal`, `branch-provider-select-popover` -> `branch-provider-select`).

### Testing
- Ran `npm run lint` which completed successfully.
- Updated Playwright smoke test selectors in `tests/e2e/smoke.spec.ts` to target the modal; no Playwright runs were executed in this rollout.
- Type-checking enforced via `tsc` as part of the lint step and succeeded.
- Verified changed code paths compile locally as part of the lint/type-check run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc62b987c832bb336e2bab5a45586)