### PR TITLE
Enforce assistant highlight requirement for branch-question API

### DIFF
--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -38,11 +38,11 @@ export const createBranchSchema = z.object({
 export const branchQuestionSchema = z.object({
   name: z.string().min(1).max(120),
   fromRef: z.string().max(120).optional(),
-  fromNodeId: z.string().min(1).optional(),
+  fromNodeId: z.string().trim().min(1),
   provider: z.enum(['openai', 'openai_responses', 'gemini', 'anthropic', 'mock']).optional(),
   model: z.string().max(200).optional(),
   question: z.string().min(1).max(6000),
-  highlight: z.string().min(1).max(8000).optional(),
+  highlight: z.string().trim().min(1).max(8000),
   thinking: z.enum(['off', 'low', 'medium', 'high']).optional(),
   switch: z.boolean().optional()
 });

--- a/tests/server/branch-question-route.test.ts
+++ b/tests/server/branch-question-route.test.ts
@@ -74,6 +74,21 @@ describe('/api/projects/[id]/branch-question', () => {
     process.env.RT_STORE = 'git';
   });
 
+  it('returns 400 when missing highlight or fromNodeId', async () => {
+    const res = await POST(
+      createRequest({
+        name: 'question',
+        question: 'why'
+      }),
+      { params: { id: 'project-1' } }
+    );
+
+    expect(res.status).toBe(400);
+    const payload = await res.json();
+    expect(payload.error.message).toBe('Invalid request body');
+    expect(payload.error.code).toBe('BAD_REQUEST');
+  });
+
   it('uses the assistant responseId for PG question branches on openai_responses', async () => {
     process.env.RT_STORE = 'pg';
     mocks.rtGetCurrentRefShadowV2.mockResolvedValue({ refId: 'ref-main', refName: 'main' });


### PR DESCRIPTION
### Motivation
- The branch-question API previously allowed creating question branches without an assistant highlight or `fromNodeId`, which the UI never permits and makes the API surface inconsistent.
- Server-side validation is needed to keep branch creation semantics legible and to prevent branches being created without node context.

### Description
- Make `fromNodeId` and `highlight` required (trimmed) in the `branchQuestionSchema` and validate them server-side so question branches cannot be created without an assistant node and highlight.
- Remove creation paths that would create a branch without node context and ensure both PG and git flows always split from the assistant message node when creating question branches in `app/api/projects/[id]/branch-question/route.ts`.
- Trim and forward `highlight` to the chat request (`chatPost`) as `highlight` and centralize the missing-context `badRequest` handling in the route.
- Add a test to `tests/server/branch-question-route.test.ts` asserting a 400 response when `fromNodeId` or `highlight` are missing.

### Testing
- Ran `npm test -- tests/server/branch-question-route.test.ts` and the test suite completed successfully.
- The updated test file executed 4 tests and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d02acf3e0832bbb6adf2f528a99fc)