### PR TITLE
Avoid graph blink by preserving cached graph history on empty refresh

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -1196,6 +1196,10 @@ export function WorkspaceClient({
       const nextNodes =
         nodes.length <= MAX_PER_BRANCH ? nodes : [nodes[0]!, ...nodes.slice(-(MAX_PER_BRANCH - 1))];
       const current = prev[branchName];
+      // Avoid wiping the cached graph when history briefly revalidates to an empty snapshot.
+      if (nextNodes.length === 0 && current?.length) {
+        return prev;
+      }
       if (current === nextNodes) return prev;
       // Avoid thrashing the graph when the active history hasn't changed meaningfully.
       if (current && current.length === nextNodes.length && current[current.length - 1]?.id === nextNodes[nextNodes.length - 1]?.id) {


### PR DESCRIPTION
### Motivation
- The graph viewport was briefly clearing (blinking) when history revalidated to a transient empty snapshot, causing a distracting UX during chat turns. 
- The intent is to avoid wiping the cached graph when a temporary empty history arrives while still allowing real tail updates to update the graph.

### Description
- Add a guard in `src/components/workspace/WorkspaceClient.tsx` to skip replacing the cached branch history when the incoming `nextNodes` array is empty but an existing cached `current` history is present. 
- Keep the existing checks that avoid re-rendering when the active history tail hasn't changed to prevent unnecessary reflows. 
- This change preserves the last non-empty history for the active branch so the graph remains visible during transient revalidations. 

### Testing
- Ran `npm test -- tests/client/WorkspaceClient.test.tsx` and all tests passed (`22 tests`).
- Verified that `WorkspaceClient` behavior around graph history patch-updating and graph panel tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9cb6d294832bbcb415c162f4da74)