### PR TITLE
Add branch visibility toggle and hide branches from graph

### DIFF
--- a/app/api/projects/[id]/branches/[refId]/hidden/route.ts
+++ b/app/api/projects/[id]/branches/[refId]/hidden/route.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { badRequest, handleRouteError } from '@/src/server/http';
+import { withProjectLock } from '@/src/server/locks';
+import { requireUser } from '@/src/server/auth';
+import { requireProjectAccess } from '@/src/server/authz';
+import { getStoreConfig } from '@/src/server/storeConfig';
+
+interface RouteContext {
+  params: { id: string; refId: string };
+}
+
+async function toggleHidden({ params, isHidden }: { params: { id: string; refId: string }; isHidden: boolean }) {
+  await requireUser();
+  const store = getStoreConfig();
+  await requireProjectAccess({ id: params.id });
+
+  if (store.mode === 'pg') {
+    return await withProjectLock(params.id, async () => {
+      const { rtSetRefHiddenShadowV1 } = await import('@/src/store/pg/branches');
+      const { rtGetCurrentRefShadowV2 } = await import('@/src/store/pg/prefs');
+      const { rtListRefsShadowV2 } = await import('@/src/store/pg/reads');
+
+      const branches = await rtListRefsShadowV2({ projectId: params.id });
+      const target = branches.find((branch) => branch.id === params.refId || branch.name === params.refId);
+      if (!target?.id) {
+        throw badRequest('Branch not found');
+      }
+
+      await rtSetRefHiddenShadowV1({ projectId: params.id, refId: target.id, isHidden });
+
+      const current = await rtGetCurrentRefShadowV2({ projectId: params.id, defaultRefName: 'main' });
+      const updatedBranches = await rtListRefsShadowV2({ projectId: params.id });
+
+      return Response.json({
+        branchName: current.refName,
+        branchId: current.refId,
+        branches: updatedBranches
+      });
+    });
+  }
+
+  const { setBranchHiddenFlag, listBranches } = await import('@git/branches');
+  const { getProject } = await import('@git/projects');
+  const { getCurrentBranchName } = await import('@git/utils');
+
+  const project = await getProject(params.id);
+  if (!project) {
+    throw badRequest('Project not found');
+  }
+
+  return await withProjectLock(project.id, async () => {
+    await setBranchHiddenFlag(project.id, params.refId, isHidden);
+    const branches = await listBranches(project.id);
+    const currentBranch = await getCurrentBranchName(project.id);
+
+    return Response.json({
+      branchName: currentBranch,
+      branches
+    });
+  });
+}
+
+export async function POST(_request: Request, { params }: RouteContext) {
+  try {
+    return await toggleHidden({ params, isHidden: true });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  try {
+    return await toggleHidden({ params, isHidden: false });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/src/git/branchConfig.ts
+++ b/src/git/branchConfig.ts
@@ -9,6 +9,7 @@ export interface BranchConfigRecord {
   provider: LLMProvider;
   model: string;
   previousResponseId?: string | null;
+  isHidden?: boolean;
 }
 
 interface BranchConfigFile {
@@ -48,5 +49,20 @@ export async function writeBranchConfigMap(projectId: string, map: Record<string
 export async function setBranchConfig(projectId: string, branchName: string, config: BranchConfigRecord): Promise<void> {
   const map = await readBranchConfigMap(projectId);
   map[branchName] = config;
+  await writeBranchConfigMap(projectId, map);
+}
+
+export async function setBranchHidden(projectId: string, branchName: string, isHidden: boolean): Promise<void> {
+  const map = await readBranchConfigMap(projectId);
+  const existing = map[branchName];
+  if (existing) {
+    map[branchName] = { ...existing, isHidden };
+  } else {
+    map[branchName] = {
+      provider: 'openai',
+      model: '',
+      isHidden
+    } as BranchConfigRecord;
+  }
   await writeBranchConfigMap(projectId, map);
 }

--- a/src/git/types.ts
+++ b/src/git/types.ts
@@ -101,6 +101,7 @@ export interface BranchSummary {
   nodeCount: number;
   isTrunk: boolean;
   isPinned?: boolean;
+  isHidden?: boolean;
   provider?: LLMProvider;
   model?: string;
 }

--- a/src/store/pg/branches.ts
+++ b/src/store/pg/branches.ts
@@ -181,3 +181,15 @@ export async function rtGetPinnedRefShadowV2(input: {
     refName: row?.ref_name ? String(row.ref_name) : null
   };
 }
+
+export async function rtSetRefHiddenShadowV1(input: { projectId: string; refId: string; isHidden: boolean }): Promise<void> {
+  const { rpc } = getPgStoreAdapter();
+  const { error } = await rpc('rt_set_ref_hidden_v1', {
+    p_project_id: input.projectId,
+    p_ref_id: input.refId,
+    p_is_hidden: input.isHidden
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/store/pg/localAdapter.ts
+++ b/src/store/pg/localAdapter.ts
@@ -22,6 +22,7 @@ const RPC_CONFIG: Record<string, { params: string[]; returnType: RpcReturnType }
   rt_set_pinned_ref_v2: { params: ['p_project_id', 'p_ref_id'], returnType: 'void' },
   rt_clear_pinned_ref_v2: { params: ['p_project_id'], returnType: 'void' },
   rt_get_pinned_ref_v2: { params: ['p_project_id'], returnType: 'set' },
+  rt_set_ref_hidden_v1: { params: ['p_project_id', 'p_ref_id', 'p_is_hidden'], returnType: 'void' },
   rt_list_projects_v1: { params: [], returnType: 'set' },
   rt_get_project_v1: { params: ['p_project_id'], returnType: 'set' },
   rt_list_project_member_ids_v1: { params: ['p_user_id'], returnType: 'set' },

--- a/src/store/pg/reads.ts
+++ b/src/store/pg/reads.ts
@@ -9,6 +9,7 @@ export interface PgBranchSummary {
   nodeCount: number;
   isTrunk: boolean;
   isPinned: boolean;
+  isHidden: boolean;
   provider?: string;
   model?: string;
 }
@@ -153,6 +154,7 @@ export async function rtListRefsShadowV2(input: { projectId: string }): Promise<
     nodeCount: Number(row.node_count ?? 0),
     isTrunk: Boolean(row.is_trunk),
     isPinned: Boolean(row.is_pinned),
+    isHidden: Boolean(row.is_hidden),
     provider: row.provider ? String(row.provider) : undefined,
     model: row.model ? String(row.model) : undefined
   }));

--- a/supabase/migrations/20260106084202_branch_visibility.sql
+++ b/supabase/migrations/20260106084202_branch_visibility.sql
@@ -1,0 +1,99 @@
+-- Add branch visibility flag and RPC helpers.
+
+alter table public.refs
+  add column if not exists is_hidden boolean not null default false;
+
+drop function if exists public.rt_set_ref_hidden_v1(uuid, uuid, boolean, integer);
+
+create function public.rt_set_ref_hidden_v1(
+  p_project_id uuid,
+  p_ref_id uuid,
+  p_is_hidden boolean default true,
+  p_lock_timeout_ms integer default 3000
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+  if not public.rt_is_project_member(p_project_id) then
+    raise exception 'Not authorized';
+  end if;
+  if p_ref_id is null then
+    raise exception 'ref id required';
+  end if;
+
+  perform set_config('lock_timeout', concat(p_lock_timeout_ms, 'ms'), true);
+
+  update public.refs r
+    set is_hidden = coalesce(p_is_hidden, false),
+        updated_at = now()
+  where r.project_id = p_project_id and r.id = p_ref_id;
+
+  if not found then
+    raise exception 'Ref not found';
+  end if;
+end;
+$$;
+
+revoke all on function public.rt_set_ref_hidden_v1(uuid, uuid, boolean, integer) from public;
+grant execute on function public.rt_set_ref_hidden_v1(uuid, uuid, boolean, integer) to authenticated;
+
+drop function if exists public.rt_list_refs_v2(uuid);
+
+create function public.rt_list_refs_v2(
+  p_project_id uuid
+)
+returns table (
+  id uuid,
+  name text,
+  head_commit text,
+  node_count bigint,
+  is_trunk boolean,
+  is_pinned boolean,
+  is_hidden boolean,
+  provider text,
+  model text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+  if not public.rt_is_project_member(p_project_id) then
+    raise exception 'Not authorized';
+  end if;
+
+  return query
+  select
+    r.id,
+    r.name,
+    coalesce(r.tip_commit_id::text, '') as head_commit,
+    coalesce(mx.max_ordinal + 1, 0)::bigint as node_count,
+    (r.name = 'main') as is_trunk,
+    (r.id = p.pinned_ref_id) as is_pinned,
+    r.is_hidden,
+    r.provider,
+    r.model
+  from public.refs r
+  left join (
+    select co.ref_id, max(co.ordinal) as max_ordinal
+    from public.commit_order co
+    where co.project_id = p_project_id
+    group by co.ref_id
+  ) mx on mx.ref_id = r.id
+  left join public.projects p on p.id = p_project_id
+  where r.project_id = p_project_id
+  order by r.is_hidden asc, (r.id = p.pinned_ref_id) desc, (r.name = 'main') desc, r.updated_at desc, r.name asc;
+end;
+$$;
+
+revoke all on function public.rt_list_refs_v2(uuid) from public;
+grant execute on function public.rt_list_refs_v2(uuid) to authenticated;


### PR DESCRIPTION
### Motivation
- Provide a way to hide noisy or private branches from the workspace rail and graph views so users can focus on relevant work.  
- Persist branch visibility across storage backends so the UI, RPCs, and Git-backed flows remain consistent.  
- Ensure hidden branches sort to the bottom of the rail and are omitted from graph payloads and the graph legend.  
- Expose an affordance in the rail to toggle visibility (eye / eye-off).  

### Description
- Add an `isHidden` flag to branch summaries and config by extending `BranchSummary` and branch config storage in `src/git/types.ts` and `src/git/branchConfig.ts`.  
- Wire visibility into Git and file-backed flows with `setBranchHidden` / `setBranchHiddenFlag` in `src/git/branchConfig.ts` and `src/git/branches.ts`, and default new branches to `isHidden: false`.  
- Add a Supabase migration `supabase/migrations/20260106084202_branch_visibility.sql` that creates `refs.is_hidden`, a `rt_set_ref_hidden_v1` RPC, and returns `is_hidden` from `rt_list_refs_v2`, and add PG adapter wiring (`src/store/pg/localAdapter.ts`, `src/store/pg/branches.ts`, `src/store/pg/reads.ts`).  
- Expose hide/unhide endpoints `POST`/`DELETE /api/projects/:id/branches/:refId/hidden` implemented at `app/api/projects/[id]/branches/[refId]/hidden/route.ts`, update the graph route (`app/api/projects/[id]/graph/route.ts`) to filter hidden refs, and update the workspace rail and graph client logic (`src/components/workspace/WorkspaceClient.tsx`, `src/components/workspace/WorkspaceGraph.tsx` usage) to sort hidden branches last and omit hidden histories; add a rail toggle using `BlueprintIcon` eye icons.  

### Testing
- Ran the client tests covering the workspace behavior with `npm test -- tests/client/WorkspaceClient.test.tsx`, which passed (`25/25` tests).  
- Unit/behavioral changes exercised in the updated `tests/client/WorkspaceClient.test.tsx` to verify sorting, UI toggle, and omission of hidden branches from graph histories.  
- The new DB migration was added as `supabase/migrations/20260106084202_branch_visibility.sql` to apply the schema and RPC changes for PG-backed stores.  
- No other CI failures observed locally while running the focused test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc8d5c13c832b9d666da5eff4e2a0)