### PR TITLE
fix: gate session tips auto-open on user history hydration

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -853,6 +853,7 @@ export function WorkspaceClient({
   });
   const HAS_SENT_MESSAGE_KEY = storageKey('user-has-sent-message');
   const [hasEverSentMessage, setHasEverSentMessage] = useState(false);
+  const [hasEverSentMessageHydrated, setHasEverSentMessageHydrated] = useState(false);
   const hasSentMessage = useMemo(
     () => nodes.some((node) => node.type === 'message' && node.role === 'user'),
     [nodes]
@@ -907,6 +908,7 @@ export function WorkspaceClient({
     if (stored === 'true') {
       setHasEverSentMessage(true);
     }
+    setHasEverSentMessageHydrated(true);
   }, [HAS_SENT_MESSAGE_KEY]);
 
   useEffect(() => {
@@ -1841,10 +1843,10 @@ export function WorkspaceClient({
   const newBranchModalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (isLoading || !isNewUser || autoOpenedHintsRef.current) return;
+    if (isLoading || !hasEverSentMessageHydrated || !isNewUser || autoOpenedHintsRef.current) return;
     setShowHints(true);
     autoOpenedHintsRef.current = true;
-  }, [isLoading, isNewUser]);
+  }, [isLoading, isNewUser, hasEverSentMessageHydrated]);
 
   useEffect(() => {
     if (!showHints) return;


### PR DESCRIPTION
### Motivation
- Session tips onboarding popover was auto-opening too frequently and showing to returning users on each mount. 
- The effect used `isNewUser` (derived from `hasEverSentMessage`) before the stored flag was hydrated, causing false positives. 
- We need to delay the auto-open until the persisted "has sent message" state is loaded from `localStorage`.

### Description
- Add a `hasEverSentMessageHydrated` state flag in `src/components/workspace/WorkspaceClient.tsx` to track when the stored value is read. 
- Set `hasEverSentMessageHydrated` after reading `HAS_SENT_MESSAGE_KEY` from `localStorage`. 
- Gate the session tips auto-open `useEffect` so it requires `hasEverSentMessageHydrated` to be true before opening the popover. 
- This preserves onboarding for true first-time users while preventing repeated popovers for returning users.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ded128a84832b9ff748c6eb531a44)