### PR TITLE
Fix: preserve Supabase auth cookies during middleware redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -187,6 +187,13 @@ function buildMaintenanceResponse(request: NextRequest): NextResponse {
   });
 }
 
+function withSupabaseCookies(source: NextResponse, target: NextResponse): NextResponse {
+  for (const cookie of source.cookies.getAll()) {
+    target.cookies.set(cookie);
+  }
+  return target;
+}
+
 export async function middleware(request: NextRequest) {
   const maintenanceEnabled = isMaintenanceModeEnabled();
   const adminUserIds = maintenanceEnabled ? getAdminUserIds() : new Set<string>();
@@ -255,7 +262,7 @@ export async function middleware(request: NextRequest) {
   if (user && pathname === '/login') {
     const redirectTo = sanitizeRedirectTo(request.nextUrl.searchParams.get('redirectTo')) ?? '/';
     const redirectUrl = new URL(redirectTo, request.url);
-    response = NextResponse.redirect(redirectUrl);
+    response = withSupabaseCookies(response, NextResponse.redirect(redirectUrl));
     return response;
   }
 
@@ -269,7 +276,7 @@ export async function middleware(request: NextRequest) {
     redirectUrl.searchParams.set('redirectTo', `${request.nextUrl.pathname}${request.nextUrl.search}`);
     redirectUrl.searchParams.set('mode', 'signin');
     redirectUrl.hash = 'existing-user';
-    response = NextResponse.redirect(redirectUrl);
+    response = withSupabaseCookies(response, NextResponse.redirect(redirectUrl));
   }
 
   return response;


### PR DESCRIPTION
### Motivation
- The middleware uses a Supabase server client that can refresh auth cookies on the initial `response`, but subsequent redirect branches create a new `NextResponse.redirect` and lose those cookies, which causes refreshed sessions to be discarded and users to be logged out after navigation gating or deploys. 
- The issue manifests during auth-gating redirects such as navigating from `/login` when already authenticated and redirecting unauthenticated requests to `/login`.

### Description
- Add a `withSupabaseCookies` helper to copy cookies from a source `NextResponse` into a target `NextResponse` so cookie sets from the Supabase client are preserved. 
- Use `withSupabaseCookies` where middleware issues redirects (the `user && pathname === '/login'` branch and the unauthenticated redirect to `/login`) so refreshed session cookies are carried into `NextResponse.redirect` responses. 
- All changes are contained in `middleware.ts` and do not alter non-redirect response paths.

### Testing
- No automated tests were run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1bf0d71c832b93a2673c1826f040)