### PR TITLE
Follow-up: generalize user message fence escaping

### DIFF
--- a/app/api/projects/[id]/chat/route.ts
+++ b/app/api/projects/[id]/chat/route.ts
@@ -61,16 +61,20 @@ function buildCanvasDiffMessage(diff: string): string {
   ].join('\n');
 }
 
+function escapeFence(text: string): string {
+  return text.replaceAll('```', '\\`\\`\\`');
+}
+
 function formatHighlightBlock(highlight: string): string {
   const fence = '```';
-  const escaped = highlight.replaceAll(fence, '\\`\\`\\`');
+  const escaped = escapeFence(highlight);
   return `${fence}text\n${escaped}\n${fence}`;
 }
 
 function buildUserMessage(input: { message?: string | null; question?: string | null; highlight?: string | null }): string {
   const highlight = input.highlight?.trim() ?? '';
-  const question = input.question?.trim() ?? '';
-  const message = input.message?.trim() ?? '';
+  const question = escapeFence(input.question?.trim() ?? '');
+  const message = escapeFence(input.message?.trim() ?? '');
 
   const parts: string[] = [];
 


### PR DESCRIPTION
### Motivation
- Prevent provider-side prompt/payload errors when users paste code blocks that include triple-backtick fences.
- The codebase only escaped backticks inside highlights, which left `message`/`question` content vulnerable to breaking provider payloads.
- Centralize fence escaping so handling is consistent and reusable across message assembly and highlight formatting.

### Description
- Add a shared helper `escapeFence` to replace occurrences of ````` ``` ````` with an escaped sequence and keep it in `app/api/projects/[id]/chat/route.ts`.
- Use `escapeFence` inside `formatHighlightBlock` to escape fences in highlighted passages before wrapping them in a code fence.
- Escape the `question` and `message` inputs via `escapeFence` before assembling the final user prompt in `buildUserMessage` so provider payloads receive safe text.

### Testing
- No automated tests were run for this change.
- No test files were added or modified as part of this follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f52676148832b82409086a5c994bd)