### PR TITLE
fix(markdown): restore inline code rendering in MarkdownWithCopy

### DIFF
--- a/src/components/workspace/MarkdownWithCopy.tsx
+++ b/src/components/workspace/MarkdownWithCopy.tsx
@@ -13,19 +13,22 @@ type MarkdownWithCopyProps = {
 };
 
 type CodeProps = {
-  inline?: boolean;
   className?: string;
   children?: React.ReactNode;
+  node?: {
+    type?: string;
+  };
 };
 
 type PreProps = {
   children?: React.ReactNode;
 };
 
-const CodeBlock = ({ inline, className, children }: CodeProps) => {
+const CodeBlock = ({ className, children, node }: CodeProps) => {
   const [copied, setCopied] = useState(false);
+  const isInline = node?.type === 'inlineCode';
 
-  if (inline) {
+  if (isInline) {
     return <code className={className}>{children}</code>;
   }
 


### PR DESCRIPTION
### Motivation
- Inline code enclosed in single backticks was being rendered as full code blocks because `react-markdown` v9 no longer provides the `inline` prop to the `code` renderer.
- `CodeBlock` previously relied on the `inline` prop to distinguish inline vs block code and defaulted to block rendering when `inline` was undefined.

### Description
- Remove dependence on the removed `inline` prop and add a `node` field to `CodeProps` to inspect the AST node type.
- Detect inline code using `node?.type === 'inlineCode'` and render `<code>` for inline values while preserving the existing block `<pre><code>` + copy button UI for code blocks.
- Keep the `pre` component passthrough and `remarkGfm` usage unchanged.

### Testing
- No automated tests were executed as part of this change.
- Manual verification was performed by inspecting the updated `MarkdownWithCopy` implementation to ensure inline/backtick detection was corrected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663aefa290832bba62d5a6d8cecf4d)