### PR TITLE
Restore inline code rendering in MarkdownWithCopy

### DIFF
--- a/src/components/workspace/MarkdownWithCopy.tsx
+++ b/src/components/workspace/MarkdownWithCopy.tsx
@@ -21,9 +21,17 @@ type CodeProps = {
   children?: React.ReactNode;
 };
 
-const InlineCode = ({ className, children }: CodeProps) => (
-  <code className={className}>{children}</code>
-);
+const InlineCode = ({ className, children }: CodeProps) => {
+  const mergedClassName = [
+    'rounded-md bg-slate-100 px-1.5 py-0.5 text-[0.85em] font-semibold text-slate-700',
+    'before:content-none after:content-none',
+    className
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return <code className={mergedClassName}>{children}</code>;
+};
 
 const CodeBlock = ({ className, children }: CodeProps) => {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
### Motivation
- Single-backtick inline code was being rendered as full code blocks because the `react-markdown` `code` component no longer provides an `inline` prop, breaking the previous inline/block discrimination in `MarkdownWithCopy`.

### Description
- Add an `InlineCode` component to render single-backtick inline code as `<code>` without block styling.
- Move block code rendering (copy button, `<pre>` wrapper and styling) into a `CodeBlock` component used by a new `PreBlock` renderer.
- `PreBlock` extracts the inner `code` element props (className and children) from `pre` children and forwards them to `CodeBlock` to preserve language classes and copy behavior.
- Update the `ReactMarkdown` `components` mapping to use `code: InlineCode` and `pre: PreBlock` so inline and block code are handled correctly.

### Testing
- Started the development server with `npm run dev`, which launched successfully and served the app.
- Ran a Playwright navigation script to visit `/projects/1` and capture a screenshot, which completed and produced an artifact (a login redirect was observed during navigation). 
- No unit tests (`vitest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677d73e8e8832b80fdde3dc90f6a50)