### PR TITLE
Use ⌘+K / ⌘+Shift+K for workspace composer and panel toggles

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -1822,7 +1822,7 @@ export function WorkspaceClient({
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (!event.metaKey || !event.shiftKey || event.ctrlKey || event.altKey) return;
-      if (event.key.toLowerCase() !== 'j') return;
+      if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
       const target = event.target as HTMLElement | null;
       if (
@@ -1845,7 +1845,7 @@ export function WorkspaceClient({
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (!event.metaKey || event.shiftKey || event.ctrlKey || event.altKey) return;
-      if (event.key.toLowerCase() !== 'j') return;
+      if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
       const target = event.target as HTMLElement | null;
       if (
@@ -3259,8 +3259,8 @@ export function WorkspaceClient({
                   <ul className="mt-2 list-disc space-y-1 pl-5 text-muted">
                     <li>⌘ + Enter to send · Shift + Enter adds a newline.</li>
                     <li>⌘ + B to toggle the rail.</li>
-                    <li>⌘ + J to toggle the composer.</li>
-                    <li>⌘ + Shift + J to collapse or restore all panels.</li>
+                    <li>⌘ + K to toggle the composer.</li>
+                    <li>⌘ + Shift + K to collapse or restore all panels.</li>
                     <li>⌘ + click a graph node to jump to its message.</li>
                     <li>← Thred graph · → Canvas.</li>
                     <li>↑ show graph/canvas · ↓ hide panel.</li>


### PR DESCRIPTION
### Motivation
- `cmd+shift+J` conflicts with Chrome history, so the workspace toggle shortcuts need to be moved to avoid the platform-level binding. 
- The session tips copy must be updated to reflect the new, non-conflicting shortcuts.

### Description
- Remapped the workspace keyboard handlers in `src/components/workspace/WorkspaceClient.tsx` to listen for `'k'` so the toggles are now `⌘+K` and `⌘+Shift+K` instead of `⌘+J` and `⌘+Shift+J`.
- Updated the session tips popover text in `src/components/workspace/WorkspaceClient.tsx` to show `⌘ + K` and `⌘ + Shift + K`.
- Preserved existing focus/streaming guards to avoid triggering shortcuts while typing or streaming.

### Testing
- Started the dev server with `npm run dev` and the server reported `Ready`, indicating the app compiled successfully.
- Ran a Playwright script to open `http://127.0.0.1:3000` and capture a screenshot, and the script completed successfully.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665e2beefc832bb3c7e4b3e589fcbc)