### PR TITLE
Enforce canvas saves before branch switches

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -901,6 +901,8 @@ export function WorkspaceClient({
       clearTimeout(autosaveSpinnerTimeoutRef.current);
       autosaveSpinnerTimeoutRef.current = null;
     }
+    autosaveSpinnerUntilRef.current = null;
+    setIsSavingArtefact(false);
   }, []);
   const saveArtefactSnapshot = useCallback(
     async ({ content, ref }: { content: string; ref: string }) => {


### PR DESCRIPTION
### Motivation
- Prevent delayed/debounced autosaves from writing to a different branch after a branch switch by cancelling pending autosaves and performing an explicit save before switching.
- Ensure autosave behavior snapshots both the canvas content and branch ref at timer creation so delayed saves never target a different branch.
- Provide a clear failure path so branch switches are halted or the user can confirm discarding unsaved changes when a pre-switch save fails.

### Description
- Added `clearPendingAutosave`, `saveArtefactSnapshot`, and `ensureCanvasSavedForBranchSwitch` helpers to centralize autosave cancellation and explicit save behavior and to abort in-flight saves via `AbortController`.
- Changed autosave scheduling to snapshot `artefactDraft` and `branchName` at timer creation and invoke `saveArtefactSnapshot({ content, ref })` when the timer fires so delayed saves always use the original ref.
- Integrated pre-switch checks into branch flows by calling `clearPendingAutosave()` and `ensureCanvasSavedForBranchSwitch()` from `switchBranch`, from branch creation when `switchToNew` is true, and after `sendEditWithStream` responses before calling `setBranchName`.
- When a pre-switch save fails, the code now prompts the user with `window.confirm` to optionally discard unsaved changes, and in-flight controllers/timeouts are cleaned up to avoid stray writes.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696963f046c0832bb880660b1ad488db)