### PR TITLE
fix: preserve user scroll interruption after streaming ends

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2507,7 +2507,9 @@ export function WorkspaceClient({
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
     shouldScrollToBottomRef.current = distance <= scrollFollowThreshold;
     if (!state.isStreaming) {
-      userInterruptedScrollRef.current = false;
+      if (distance <= scrollFollowThreshold) {
+        userInterruptedScrollRef.current = false;
+      }
       return;
     }
     if (distance > scrollFollowThreshold) {


### PR DESCRIPTION
### Motivation
- Prevent the message list from auto-scrolling to the bottom immediately after an assistant stream finishes when the user has intentionally scrolled up, by avoiding clearing the user-interruption flag unconditionally.

### Description
- Change `handleMessageListScroll` in `src/components/workspace/WorkspaceClient.tsx` so that `userInterruptedScrollRef.current` is only cleared when not streaming and the scroll distance is within the follow threshold (`distance <= scrollFollowThreshold`), preserving the interruption state if the user remains scrolled up.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a751d0ee0832b92dd88b07fd46ce0)