### PR TITLE
Map right-hand graph/canvas toggle to ⌥⌘B

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2310,25 +2310,22 @@ export function WorkspaceClient({
         setInsightTab('canvas');
         return;
       }
-      if (event.key === 'ArrowDown') {
+      if (event.metaKey && event.altKey && !event.shiftKey && !event.ctrlKey && event.key.toLowerCase() === 'b') {
         const target = event.target as HTMLElement | null;
-        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        if (
+          target &&
+          (target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.tagName === 'SELECT' ||
+            target.isContentEditable)
+        ) {
           return;
         }
-        if (!insightCollapsed) {
-          event.preventDefault();
-          collapseInsights();
-        }
-        return;
-      }
-      if (event.key === 'ArrowUp') {
-        const target = event.target as HTMLElement | null;
-        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
-          return;
-        }
+        event.preventDefault();
         if (insightCollapsed) {
-          event.preventDefault();
           expandInsights();
+        } else {
+          collapseInsights();
         }
         return;
       }
@@ -3947,7 +3944,7 @@ export function WorkspaceClient({
                     <li>⌘ + Shift + J to collapse or restore all panels.</li>
                     <li>⌘ + click a graph node to jump to its message.</li>
                     <li>← Thred graph · → Canvas.</li>
-                    <li>↑ show graph/canvas · ↓ hide panel.</li>
+                    <li>⌥⌘B to toggle the graph/canvas panel.</li>
                     <li>Branch to try edits without losing the {TRUNK_LABEL}.</li>
                     <li>Canvas edits are per-branch; merge intentionally carries a diff summary.</li>
                   </ul>


### PR DESCRIPTION
### Motivation

- Preserve the ArrowUp/ArrowDown keys for chat navigation and avoid stealing them for panel toggling.
- Align the RHS panel toggle with a familiar secondary-sidebar style mapping where possible and avoid common browser/Finder shortcuts.

### Description

- Replace the ArrowUp/ArrowDown panel toggle logic in `src/components/workspace/WorkspaceClient.tsx` with a `metaKey + altKey + B` (`⌥⌘B`) handler that toggles collapse/expand of the graph/canvas panel.
- Add input focus guards (including `SELECT`) so the shortcut does not trigger while typing or interacting with form controls.
- Update the session tips text in `WorkspaceClient.tsx` to reflect the new `⌥⌘B` shortcut.

### Testing

- Started the dev server with `npm run dev` and Next compiled successfully.
- Ran a lightweight Playwright script that visited `http://127.0.0.1:3000` and saved a screenshot to `artifacts/home.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd2d6d32c832bb01b89d8ddb608a3)