### PR TITLE
fix: move workspace shortcuts off cmd-shift-J conflict

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2344,7 +2344,7 @@ export function WorkspaceClient({
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (!event.metaKey || !event.shiftKey || event.ctrlKey || event.altKey) return;
-      if (event.key.toLowerCase() !== 'j') return;
+      if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
       const target = event.target as HTMLElement | null;
       if (
@@ -2367,7 +2367,7 @@ export function WorkspaceClient({
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (!event.metaKey || event.shiftKey || event.ctrlKey || event.altKey) return;
-      if (event.key.toLowerCase() !== 'j') return;
+      if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
       const target = event.target as HTMLElement | null;
       if (
@@ -3943,8 +3943,8 @@ export function WorkspaceClient({
                   <ul className="mt-2 list-disc space-y-1 pl-5 text-muted">
                     <li>⌘ + Enter to send · Shift + Enter adds a newline.</li>
                     <li>⌘ + B to toggle the rail.</li>
-                    <li>⌘ + J to toggle the composer.</li>
-                    <li>⌘ + Shift + J to collapse or restore all panels.</li>
+                    <li>⌘ + K to toggle the composer.</li>
+                    <li>⌘ + Shift + K to collapse or restore all panels.</li>
                     <li>⌘ + click a graph node to jump to its message.</li>
                     <li>← Thred graph · → Canvas.</li>
                     <li>↑ show graph/canvas · ↓ hide panel.</li>


### PR DESCRIPTION
### Motivation
- Avoid a browser shortcut conflict where `⌘+Shift+J` is already used by Chrome history by moving workspace toggles to `⌘+K` and `⌘+Shift+K`, and keep the UI help consistent.

### Description
- Replace the `event.key` checks from `'j'` to `'k'` for the composer and panel toggle handlers in `src/components/workspace/WorkspaceClient.tsx`.
- Update the session tips popover copy in `src/components/workspace/WorkspaceClient.tsx` to show `⌘ + K` and `⌘ + Shift + K` instead of the previous keys.

### Testing
- Started the Next.js dev server (`next dev`) successfully and ran an automated Playwright script to capture a screenshot of the workspace UI, which produced an artifact `artifacts/workspace-shortcuts.png`.
- No unit or integration test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd2cbe130832b8f92c6d431cce91e)