### PR TITLE
Change graph/canvas panel hotkey to Ctrl+B and update session tips

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2310,7 +2310,7 @@ export function WorkspaceClient({
         setInsightTab('canvas');
         return;
       }
-      if (event.metaKey && event.altKey && !event.shiftKey && !event.ctrlKey && event.key.toLowerCase() === 'b') {
+      if (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'b') {
         const target = event.target as HTMLElement | null;
         if (
           target &&
@@ -3944,7 +3944,7 @@ export function WorkspaceClient({
                     <li>⌘ + Shift + K to collapse or restore all panels.</li>
                     <li>⌘ + click a graph node to jump to its message.</li>
                     <li>← Thred graph · → Canvas.</li>
-                    <li>⌥⌘B to toggle the graph/canvas panel.</li>
+                    <li>⌃ + B to toggle the graph/canvas panel.</li>
                     <li>Branch to try edits without losing the {TRUNK_LABEL}.</li>
                     <li>Canvas edits are per-branch; merge intentionally carries a diff summary.</li>
                   </ul>


### PR DESCRIPTION
### Motivation
- Avoid conflicts with existing macOS/Chrome shortcuts and preserve arrow-key chat navigation by moving the graph/canvas panel toggle to `Ctrl+B` instead of the previous `⌥⌘B` mapping.

### Description
- Update the workspace key handler in `src/components/workspace/WorkspaceClient.tsx` to trigger the graph/canvas panel toggle on `Ctrl+B` (check `event.ctrlKey` and ensure no other modifiers) and refresh the Session tips copy to show `Ctrl+B`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cea155588832bb97c404c62cef212)