### PR TITLE
Add token usage estimation UI and API

### DIFF
--- a/app/api/projects/[id]/token-usage/route.ts
+++ b/app/api/projects/[id]/token-usage/route.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { tokenUsageRequestSchema } from '@/src/server/schemas';
+import { badRequest, handleRouteError } from '@/src/server/http';
+import { requireUser } from '@/src/server/auth';
+import { getStoreConfig } from '@/src/server/storeConfig';
+import { requireProjectEditor } from '@/src/server/authz';
+import { getBranchConfigMap, resolveBranchConfig } from '@/src/server/branchConfig';
+import type { LLMProvider } from '@/src/server/llm';
+import { getProviderTokenLimit } from '@/src/server/providerCapabilities';
+import { buildUserMessage } from '@/src/server/chatMessages';
+import { buildMessagesForCompletion } from '@/src/server/chatPayload';
+import { countCharactersForMessages, estimateTokensFromChars } from '@/src/shared/tokenEstimate';
+
+interface RouteContext {
+  params: { id: string };
+}
+
+async function getPreferredBranch(projectId: string): Promise<{ id: string | null; name: string }> {
+  const store = getStoreConfig();
+  if (store.mode === 'pg') {
+    const { resolveCurrentRef } = await import('@/src/server/pgRefs');
+    const current = await resolveCurrentRef(projectId, 'main');
+    return { id: current.id, name: current.name };
+  }
+  const { getCurrentBranchName } = await import('@git/utils');
+  const name = await getCurrentBranchName(projectId).catch(() => 'main');
+  return { id: null, name };
+}
+
+function labelForProvider(provider: LLMProvider): string {
+  if (provider === 'openai' || provider === 'openai_responses') return 'OpenAI';
+  if (provider === 'gemini') return 'Gemini';
+  if (provider === 'anthropic') return 'Anthropic';
+  return 'Mock';
+}
+
+export async function POST(request: Request, { params }: RouteContext) {
+  try {
+    await requireUser();
+    const store = getStoreConfig();
+    await requireProjectEditor({ id: params.id });
+
+    const body = await request.json().catch(() => null);
+    const parsed = tokenUsageRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      throw badRequest('Invalid request body', { issues: parsed.error.flatten() });
+    }
+
+    const { message, question, highlight, llmProvider, ref } = parsed.data;
+    const userContent = buildUserMessage({ message, question, highlight });
+    if (!userContent.trim()) {
+      throw badRequest('Message is required.');
+    }
+
+    const preferred = await getPreferredBranch(params.id);
+    const requestedRefName = ref?.trim() || null;
+    const targetRefName = requestedRefName ?? preferred.name;
+    let targetRefId: string | null = null;
+    if (store.mode === 'pg') {
+      if (requestedRefName) {
+        const { resolveRefByName } = await import('@/src/server/pgRefs');
+        targetRefId = (await resolveRefByName(params.id, requestedRefName)).id;
+      } else {
+        targetRefId = preferred.id;
+      }
+    }
+    if (store.mode === 'pg' && !targetRefId) {
+      throw badRequest(`Branch ${targetRefName} is missing ref id`);
+    }
+
+    const branchConfigMap = await getBranchConfigMap(params.id);
+    const activeConfig = branchConfigMap[targetRefName] ?? resolveBranchConfig();
+    const provider = activeConfig.provider;
+    const modelName = activeConfig.model;
+    if (llmProvider && llmProvider !== provider) {
+      throw badRequest(
+        `Branch ${targetRefName} is locked to ${labelForProvider(provider)} (${modelName}). Create a new branch to switch.`
+      );
+    }
+
+    const tokenLimit = await getProviderTokenLimit(provider, modelName);
+    const canvasToolsEnabled = store.mode === 'pg' && process.env.RT_CANVAS_TOOLS === 'true';
+    const { messages } = await buildMessagesForCompletion({
+      projectId: params.id,
+      ref: targetRefName,
+      tokenLimit,
+      userContent,
+      includeCanvasDiff: canvasToolsEnabled,
+      refId: targetRefId
+    });
+
+    const charCount = countCharactersForMessages(messages);
+    const tokenEstimate = estimateTokensFromChars(charCount);
+
+    return Response.json({ charCount, tokenEstimate, tokenLimit });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/src/server/chatMessages.ts
+++ b/src/server/chatMessages.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+function formatHighlightBlock(highlight: string): string {
+  const fence = '```';
+  const escaped = highlight.replaceAll(fence, '\\`\\`\\`');
+  return `${fence}text\n${escaped}\n${fence}`;
+}
+
+export function buildUserMessage(input: { message?: string | null; question?: string | null; highlight?: string | null }): string {
+  const highlight = input.highlight?.trim() ?? '';
+  const question = input.question?.trim() ?? '';
+  const message = input.message?.trim() ?? '';
+
+  const parts: string[] = [];
+
+  if (highlight) {
+    parts.push('Highlighted passage:', formatHighlightBlock(highlight));
+  }
+
+  if (question) {
+    parts.push('Question:', question);
+  }
+
+  if (message && parts.length === 0) {
+    return message;
+  }
+
+  if (message) {
+    parts.push('Additional message:', message);
+  }
+
+  return parts.join('\n\n');
+}

--- a/src/server/chatPayload.ts
+++ b/src/server/chatPayload.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import type { ChatMessage } from '@/src/server/context';
+import { buildChatContext } from '@/src/server/context';
+import { buildUnifiedDiff } from '@/src/server/canvasDiff';
+import { getStoreConfig } from '@/src/server/storeConfig';
+
+export type CanvasDiffResult = {
+  hasChanges: boolean;
+  diff: string;
+  message: string;
+};
+
+function buildCanvasDiffMessage(diff: string): string {
+  return [
+    'Canvas update (do not display to user). Apply this diff to your internal canvas state:',
+    '```diff',
+    diff.trim(),
+    '```'
+  ].join('\n');
+}
+
+export async function getCanvasDiffData({
+  projectId,
+  refId,
+  includeMessage
+}: {
+  projectId: string;
+  refId: string | null;
+  includeMessage: boolean;
+}): Promise<CanvasDiffResult> {
+  const store = getStoreConfig();
+  if (store.mode !== 'pg' || !refId) {
+    return { hasChanges: false, diff: '', message: '' };
+  }
+
+  const { rtGetCanvasHashesShadowV2, rtGetCanvasPairShadowV2 } = await import('@/src/store/pg/reads');
+  const hashes = await rtGetCanvasHashesShadowV2({ projectId, refId });
+  const hasChanges = Boolean(hashes.draftHash && hashes.draftHash !== hashes.artefactHash);
+  if (!hasChanges) {
+    return { hasChanges: false, diff: '', message: '' };
+  }
+  if (!includeMessage) {
+    return { hasChanges, diff: '', message: '' };
+  }
+  const pair = await rtGetCanvasPairShadowV2({ projectId, refId });
+  const diff = buildUnifiedDiff(pair.artefactContent ?? '', pair.draftContent ?? '');
+  const message = diff.trim().length > 0 ? buildCanvasDiffMessage(diff) : '';
+  return { hasChanges, diff, message };
+}
+
+export async function buildMessagesForCompletion({
+  projectId,
+  ref,
+  tokenLimit,
+  userContent,
+  includeCanvasDiff,
+  refId
+}: {
+  projectId: string;
+  ref: string;
+  tokenLimit: number;
+  userContent: string;
+  includeCanvasDiff: boolean;
+  refId: string | null;
+}): Promise<{ messages: ChatMessage[]; canvasDiff: CanvasDiffResult }> {
+  const context = await buildChatContext(projectId, { tokenLimit, ref });
+  const canvasDiff = await getCanvasDiffData({ projectId, refId, includeMessage: includeCanvasDiff });
+  const messages: ChatMessage[] = [
+    ...context.messages,
+    ...(canvasDiff.message ? [{ role: 'user', content: canvasDiff.message }] : []),
+    { role: 'user', content: userContent }
+  ];
+  return { messages, canvasDiff };
+}

--- a/src/server/schemas.ts
+++ b/src/server/schemas.ts
@@ -27,6 +27,19 @@ export const chatRequestSchema = z
 
 export type CreateProjectInput = z.infer<typeof createProjectSchema>;
 export type ChatRequestInput = z.infer<typeof chatRequestSchema>;
+export type TokenUsageRequestInput = z.infer<typeof tokenUsageRequestSchema>;
+
+export const tokenUsageRequestSchema = z
+  .object({
+    message: z.string().min(1).max(CHAT_LIMITS.messageMaxChars).optional(),
+    question: z.string().min(1).max(CHAT_LIMITS.questionMaxChars).optional(),
+    highlight: z.string().min(1).max(CHAT_LIMITS.highlightMaxChars).optional(),
+    llmProvider: z.enum(['openai', 'openai_responses', 'gemini', 'anthropic', 'mock']).optional(),
+    ref: z.string().min(1).max(120).optional()
+  })
+  .refine((value) => Boolean(value.message?.trim() || value.question?.trim()), {
+    message: 'Message or question is required.'
+  });
 
 export const createBranchSchema = z.object({
   name: z.string().min(1).max(120),

--- a/src/shared/tokenEstimate.ts
+++ b/src/shared/tokenEstimate.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { flattenMessageContent, type MessageContent } from '@/src/shared/thinkingTraces';
+
+export type TokenEstimator = (input: string) => number;
+
+export const estimateTokensFromChars = (chars: number): number => {
+  return Math.ceil(chars / 3);
+};
+
+export const estimateTokensFromText = (text: string, estimator?: TokenEstimator): number => {
+  if (estimator) {
+    return estimator(text);
+  }
+  return estimateTokensFromChars(text.length);
+};
+
+export const countCharacters = (content: MessageContent): number => {
+  return flattenMessageContent(content).length;
+};
+
+export const countCharactersForMessages = (messages: { content: MessageContent }[]): number => {
+  return messages.reduce((total, message) => total + countCharacters(message.content), 0);
+};


### PR DESCRIPTION
### Motivation
- Surface an estimate of current token usage to the user in the composer so users can see how large their payload is relative to model limits.  
- Use the exact same chat payload construction used for completions so the estimate reflects the real context sent to the LLM.  
- Provide a simple chars/3 estimator now while leaving an extension point for a proper tokenizer later.

### Description
- Introduce shared message/payload helpers: `src/server/chatMessages.ts` and `src/server/chatPayload.ts` to centralize user message formatting and build the chat payload used for completions.  
- Add token estimation utilities in `src/shared/tokenEstimate.ts` implementing `chars / 3` and character counting helpers.  
- Add a new token-usage API at `app/api/projects/[id]/token-usage/route.ts` and request schema in `src/server/schemas.ts` that returns `charCount`, `tokenEstimate`, and `tokenLimit` for the current payload.  
- Wire the composer UI (`src/components/workspace/WorkspaceClient.tsx`) to request token usage with debounce and render an annular usage ring and tooltip explaining the simple estimate; handle errors and loading state.  
- Update the chat route to reuse the centralized payload builder (`buildMessagesForCompletion`) so the server uses consistent assembly for both completions and estimates.

### Testing
- Started the local dev server (`npm run dev`) and exercised the running app; captured a Playwright screenshot of the dev homepage (login view) to verify the server started and UI is reachable. (succeeded)  
- Verified the new API route responds during local runs by exercising the composer flow in the running app (manual verification during dev server run).  
- No automated unit tests or `vitest` suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf637a1d0832b89666888f67b500f)