### PR TITLE
Fix graph panel blinking during refresh

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -4403,7 +4403,7 @@ export function WorkspaceClient({
                   <div className="flex flex-1 min-h-0 flex-col">
                     {insightTab === 'graph' ? (
                       <div className="flex-1 min-h-0" data-testid="graph-panel">
-                        {graphHistoryLoading ? (
+                        {graphHistoryLoading && !graphHistories ? (
                           <div className="flex h-full items-center justify-center">
                             <div className="h-full w-full animate-pulse rounded-2xl bg-slate-100" />
                           </div>


### PR DESCRIPTION
### Motivation
- Prevent the graph widget from blinking when histories refresh because the loading skeleton was shown whenever `graphHistoryLoading` was true, which replaced the visible graph even when cached `graphHistories` existed.

### Description
- Change in `src/components/workspace/WorkspaceClient.tsx` to only show the loading placeholder when `graphHistoryLoading && !graphHistories`, keeping the cached graph visible during background refreshes.

### Testing
- Attempted a Playwright snapshot run to validate the UI, which failed with `net::ERR_EMPTY_RESPONSE` because `http://localhost:3000` was not reachable so the automated check did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf1a167e4832bb67a30e2f25fff87)