### PR TITLE
Avoid extra about:blank tab when creating projects

### DIFF
--- a/src/components/projects/CreateProjectForm.tsx
+++ b/src/components/projects/CreateProjectForm.tsx
@@ -43,7 +43,10 @@ export function CreateProjectForm({
     setError(null);
     let pendingTab: Window | null = null;
     if (openInNewTab && typeof window !== 'undefined') {
-      pendingTab = window.open('about:blank', '_blank', 'noopener,noreferrer');
+      pendingTab = window.open('', '_blank');
+      if (pendingTab) {
+        pendingTab.opener = null;
+      }
     }
 
     try {


### PR DESCRIPTION
### Motivation
- The new-tab project creation flow could leave an orphaned `about:blank` tab because the placeholder was opened with `noopener`, losing the window handle and causing a second tab to be opened when navigating to the created project URL.

### Description
- Open the placeholder tab with `window.open('', '_blank')` and clear its `opener` via `pendingTab.opener = null` so the same tab is navigated to the new project URL while preserving the fallback `window.open(url, '_blank', 'noopener,noreferrer')` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697087e7f558832b9f1e42509b419562)