### PR TITLE
Rebind graph panel hotkey to Option+B

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2317,7 +2317,7 @@ export function WorkspaceClient({
         setInsightTab('canvas');
         return;
       }
-      if (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'b') {
+      if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey && event.key.toLowerCase() === 'b') {
         const target = event.target as HTMLElement | null;
         if (
           target &&
@@ -3966,7 +3966,7 @@ export function WorkspaceClient({
                     <li>⌘ + Shift + K to collapse or restore all panels.</li>
                     <li>⌘ + click a graph node to jump to its message.</li>
                     <li>← Thred graph · → Canvas.</li>
-                    <li>⌃ + B to toggle the graph/canvas panel.</li>
+                    <li>⌥ + B to toggle the graph/canvas panel.</li>
                     <li>Branch to try edits without losing the {TRUNK_LABEL}.</li>
                     <li>Canvas edits are per-branch; merge intentionally carries a diff summary.</li>
                   </ul>


### PR DESCRIPTION
### Motivation
- Align the keyboard shortcut for toggling the graph/canvas panel with the preferred modifier by switching from Control to Option so the binding is available on both sides of the keyboard.

### Description
- Change the key handler in `src/components/workspace/WorkspaceClient.tsx` to use `event.altKey` instead of `event.ctrlKey` for the `'b'` toggle and update the session tips copy to show `⌥ + B`.

### Testing
- Started the dev server with `npm run dev` which compiled and served the app successfully. 
- Ran an automated Playwright script that opened the app, opened the Session Tips popover, and captured a screenshot showing the updated `⌥ + B` tip, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971442ade98832b89ab6d8ff89553ff)