### PR TITLE
feat: send workspace share invite emails

### DIFF
--- a/src/server/workspaceInvites.ts
+++ b/src/server/workspaceInvites.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Benjamin F. Hall. All rights reserved.
+
+import { createSupabaseAdminClient } from '@/src/server/supabase/admin';
+import { createSupabaseServerClient } from '@/src/server/supabase/server';
+import { getRequestOrigin } from '@/src/server/requestOrigin';
+
+const REGISTERED_ERROR_HINTS = ['already', 'registered'];
+
+function looksLikeAlreadyRegistered(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return REGISTERED_ERROR_HINTS.every((hint) => normalized.includes(hint));
+}
+
+function buildInviteRedirect(projectId: string): string | undefined {
+  const origin = getRequestOrigin();
+  if (!origin) return undefined;
+  const redirectTo = `/projects/${projectId}`;
+  return `${origin}/auth/callback?redirectTo=${encodeURIComponent(redirectTo)}`;
+}
+
+export async function sendWorkspaceInviteEmail(input: {
+  projectId: string;
+  projectName: string;
+  recipientEmail: string;
+  inviterEmail: string | null;
+}): Promise<void> {
+  const emailRedirectTo = buildInviteRedirect(input.projectId);
+  const invitePayload = {
+    project_id: input.projectId,
+    project_name: input.projectName,
+    invited_by: input.inviterEmail ?? undefined
+  };
+
+  const admin = createSupabaseAdminClient();
+  const { error: inviteError } = await admin.auth.admin.inviteUserByEmail(input.recipientEmail, {
+    redirectTo: emailRedirectTo,
+    data: invitePayload
+  });
+
+  if (!inviteError) {
+    return;
+  }
+
+  if (!looksLikeAlreadyRegistered(inviteError.message)) {
+    throw new Error(inviteError.message);
+  }
+
+  const supabase = createSupabaseServerClient();
+  const { error: otpError } = await supabase.auth.signInWithOtp({
+    email: input.recipientEmail,
+    options: {
+      shouldCreateUser: false,
+      emailRedirectTo,
+      data: invitePayload
+    }
+  });
+  if (otpError) {
+    throw new Error(otpError.message);
+  }
+}


### PR DESCRIPTION
### Motivation
- Notify recipients when a workspace is shared so they can register or sign in and land back in the shared workspace.
- Reuse existing Supabase auth email flows for both new and already-registered users so invite handling is consistent with auth emails.
- Do not let transient email failures block creating the project invite in the database.

### Description
- Add `src/server/workspaceInvites.ts` with `sendWorkspaceInviteEmail` that calls `admin.inviteUserByEmail` and falls back to `signInWithOtp` for already-registered addresses, attaching `project_id`/`project_name`/`invited_by` metadata and a redirect to the workspace callback URL.
- Update `app/api/projects/[id]/members/route.ts` to trigger `sendWorkspaceInviteEmail` after creating a project invite and to log failures without preventing the API from returning success.
- Build invite redirect using `getRequestOrigin()` so signup/signin email links return the user to `/projects/{id}` after completing auth.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f4b83764832bb76ce0571fdccf97)