### PR TITLE
feat: show shared workspace indicator in rails

### DIFF
--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -5,7 +5,7 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { CreateProjectForm } from '@/src/components/projects/CreateProjectForm';
-import { ArchiveBoxArrowDownIcon, CheckIcon, ChevronRightIcon } from '@/src/components/workspace/HeroIcons';
+import { ArchiveBoxArrowDownIcon, CheckIcon, ChevronRightIcon, ShareIcon } from '@/src/components/workspace/HeroIcons';
 import { BlueprintIcon } from '@/src/components/ui/BlueprintIcon';
 import { AuthRailStatus } from '@/src/components/auth/AuthRailStatus';
 import { APP_NAME, storageKey } from '@/src/config/app';
@@ -147,6 +147,11 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                           <ul className="grid min-w-0 grid-cols-1 gap-2">
                             {recentProjects.map((project) => {
                               const isConfirming = confirming.has(project.id);
+                              const showSharedIndicator = project.isOwner === false;
+                              const sharedTooltip = project.sharedByEmail ?? 'Shared workspace';
+                              const sharedLabel = project.sharedByEmail
+                                ? `Shared by ${project.sharedByEmail}`
+                                : 'Shared workspace';
                               return (
                                 <li
                                   key={project.id}
@@ -163,27 +168,43 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                                         {dateFormatter.format(new Date(project.lastModified))}
                                       </div>
                                     </Link>
-                                    <button
-                                      type="button"
-                                      onClick={() => {
-                                        if (isConfirming) {
-                                          handleArchive(project.id);
-                                        } else {
-                                          setConfirming((prev) => new Set(prev).add(project.id));
-                                        }
-                                      }}
-                                      data-confirm-action="true"
-                                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
-                                        isConfirming
-                                          ? 'border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'
-                                          : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
-                                      }`}
-                                      aria-label={isConfirming ? 'Confirm archive' : 'Archive workspace'}
-                                      data-testid="archive-workspace"
-                                      data-project-id={project.id}
-                                    >
-                                      {isConfirming ? <CheckIcon className="h-4 w-4" /> : <ArchiveBoxArrowDownIcon className="h-4 w-4" />}
-                                    </button>
+                                    <div className="flex items-center gap-2">
+                                      {showSharedIndicator ? (
+                                        <span
+                                          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-divider bg-white text-slate-600 shadow-sm"
+                                          title={sharedTooltip}
+                                          aria-label={sharedLabel}
+                                          data-testid="shared-workspace-indicator"
+                                        >
+                                          <ShareIcon className="h-4 w-4" />
+                                        </span>
+                                      ) : null}
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          if (isConfirming) {
+                                            handleArchive(project.id);
+                                          } else {
+                                            setConfirming((prev) => new Set(prev).add(project.id));
+                                          }
+                                        }}
+                                        data-confirm-action="true"
+                                        className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
+                                          isConfirming
+                                            ? 'border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'
+                                            : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
+                                        }`}
+                                        aria-label={isConfirming ? 'Confirm archive' : 'Archive workspace'}
+                                        data-testid="archive-workspace"
+                                        data-project-id={project.id}
+                                      >
+                                        {isConfirming ? (
+                                          <CheckIcon className="h-4 w-4" />
+                                        ) : (
+                                          <ArchiveBoxArrowDownIcon className="h-4 w-4" />
+                                        )}
+                                      </button>
+                                    </div>
                                   </div>
                                 </li>
                               );
@@ -218,6 +239,11 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                             <ul className="grid min-w-0 grid-cols-1 gap-2">
                               {archivedProjects.map((project) => {
                                 const isConfirming = confirming.has(project.id);
+                                const showSharedIndicator = project.isOwner === false;
+                                const sharedTooltip = project.sharedByEmail ?? 'Shared workspace';
+                                const sharedLabel = project.sharedByEmail
+                                  ? `Shared by ${project.sharedByEmail}`
+                                  : 'Shared workspace';
                                 return (
                                   <li
                                     key={project.id}
@@ -232,6 +258,16 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                                       >
                                         {project.name}
                                       </span>
+                                      {showSharedIndicator ? (
+                                        <span
+                                          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-divider bg-white text-slate-600 shadow-sm"
+                                          title={sharedTooltip}
+                                          aria-label={sharedLabel}
+                                          data-testid="shared-workspace-indicator"
+                                        >
+                                          <ShareIcon className="h-4 w-4" />
+                                        </span>
+                                      ) : null}
                                       <button
                                         type="button"
                                         onClick={() => {

--- a/src/components/workspace/HeroIcons.tsx
+++ b/src/components/workspace/HeroIcons.tsx
@@ -90,3 +90,7 @@ export function ConsoleIcon({ className }: IconProps) {
 export function PlusIcon({ className }: IconProps) {
   return <BlueprintIcon icon="folder-new" className={className} />;
 }
+
+export function ShareIcon({ className }: IconProps) {
+  return <BlueprintIcon icon="share" className={className} />;
+}

--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -52,6 +52,7 @@ import {
   PlusIcon,
   QuestionMarkCircleIcon,
   SearchIcon,
+  ShareIcon,
   Square2StackIcon,
   XMarkIcon
 } from './HeroIcons';
@@ -738,6 +739,9 @@ export function WorkspaceClient({
     isPgMode &&
     (features.uiShareMode === 'all' || (features.uiShareMode === 'admins' && Boolean(project.isOwner)));
   const canShare = isPgMode && Boolean(project.isOwner);
+  const showSharedIndicator = project.isOwner === false;
+  const sharedTooltip = project.sharedByEmail ?? 'Shared workspace';
+  const sharedLabel = project.sharedByEmail ? `Shared by ${project.sharedByEmail}` : 'Shared workspace';
   const [showShareModal, setShowShareModal] = useState(false);
   const [shareEmail, setShareEmail] = useState('');
   const [shareRole, setShareRole] = useState<'viewer' | 'editor'>('viewer');
@@ -3633,7 +3637,19 @@ export function WorkspaceClient({
             {!ctx.railCollapsed ? (
               <div className="flex min-h-0 flex-1 flex-col gap-3">
                 <div className="rounded-2xl border border-divider/70 bg-white/80 px-3 py-2 shadow-sm">
-                  <div className="truncate text-xs font-semibold text-slate-800">{project.name}</div>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="truncate text-xs font-semibold text-slate-800">{project.name}</div>
+                    {showSharedIndicator ? (
+                      <span
+                        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-divider bg-white text-slate-600 shadow-sm"
+                        title={sharedTooltip}
+                        aria-label={sharedLabel}
+                        data-testid="shared-workspace-indicator"
+                      >
+                        <ShareIcon className="h-3.5 w-3.5" />
+                      </span>
+                    ) : null}
+                  </div>
                   <div className="truncate text-[11px] text-muted">{project.description ?? 'No description provided.'}</div>
                 </div>
                 <div className="flex min-h-0 flex-1 flex-col space-y-3 overflow-hidden">

--- a/src/git/types.ts
+++ b/src/git/types.ts
@@ -93,6 +93,7 @@ export interface ProjectMetadata {
   branchName?: string;
   pinnedBranchName?: string;
   isOwner?: boolean;
+  sharedByEmail?: string | null;
 }
 
 export interface BranchSummary {


### PR DESCRIPTION
### Motivation
- Indicate to users when a workspace was shared to them (they are not the owner) by surfacing a small icon and tooltip in the Home and Workspace rails. 
- Surface the sharer information so the tooltip can display the sharer email when available.

### Description
- Extend `ProjectMetadata` with `sharedByEmail?: string | null` to carry sharer metadata. 
- Add a `ShareIcon` helper in `src/components/workspace/HeroIcons.tsx` and render a shared-workspace indicator in `src/components/home/HomePageContent.tsx` and `src/components/workspace/WorkspaceClient.tsx` with an accessible `aria-label` and tooltip. 
- Populate `isOwner` and `sharedByEmail` for PG-backed projects by calling `rtListProjectMembersShadowV1` in `app/page.tsx` and `app/projects/[id]/page.tsx` and pass these fields into the UI so the rails can decide whether to show the indicator. 

### Testing
- Started the local dev server with `npm run dev` and the app compiled and served successfully. 
- Executed a Playwright script that loaded the homepage and saved a screenshot at `artifacts/shared-workspace-indicator-home.png`, which completed successfully. 
- No unit/vitest suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69723e920c5c832bbf3d6b3b5f8a5970)