### PR TITLE
UX: Pin user message to top and disable auto-follow during streaming (add go-to-bottom)

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2612,7 +2612,7 @@ export function WorkspaceClient({
   const scrollFollowThreshold = 72;
   const previousVisibleCountRef = useRef(0);
   const previousVisibleBranchRef = useRef<string | null>(null);
-  const lastOptimisticTimestampRef = useRef<number | null>(null);
+  const lastOptimisticScrollKeyRef = useRef<string | null>(null);
   const [pendingScrollTo, setPendingScrollTo] = useState<{ nodeId: string; targetBranch: string } | null>(null);
   const [highlightedNodeId, setHighlightedNodeId] = useState<string | null>(null);
   const [activeBranchHighlight, setActiveBranchHighlight] = useState<{ nodeId: string; text: string } | null>(null);
@@ -3013,12 +3013,14 @@ export function WorkspaceClient({
 
   useEffect(() => {
     if (!optimisticUserNode) return;
-    if (lastOptimisticTimestampRef.current === optimisticUserNode.timestamp) return;
-    lastOptimisticTimestampRef.current = optimisticUserNode.timestamp;
+    if (optimisticUserNode.createdOnBranch && optimisticUserNode.createdOnBranch !== branchName) return;
+    const scrollKey = `${optimisticUserNode.timestamp}:${branchName}`;
+    if (lastOptimisticScrollKeyRef.current === scrollKey) return;
+    lastOptimisticScrollKeyRef.current = scrollKey;
     shouldScrollToBottomRef.current = false;
     userInterruptedScrollRef.current = false;
     scrollNodeToTop(optimisticUserNode.id);
-  }, [optimisticUserNode, scrollNodeToTop]);
+  }, [optimisticUserNode, branchName, visibleNodes.length, scrollNodeToTop]);
 
   const switchBranch = async (name: string) => {
     if (name === branchName) return;


### PR DESCRIPTION
### Motivation
- Align chat scrolling with UX expectations so a newly submitted user message is pinned at the top and assistant streaming does not yank the viewport, while still offering a one-time jump to the bottom when needed.

### Description
- Update `WorkspaceClient.tsx` to pin optimistic user messages to the top by adding `lastOptimisticTimestampRef`, `scrollNodeToTop` and related scroll helpers, and to set `shouldScrollToBottomRef.current = false` when sending optimistic messages (`sendDraft`, `sendQuestionWithStream`, `sendEditWithStream`).
- Disable automatic follow during streaming (`state.isStreaming`) and simplify scroll handling by removing the resume-timer logic and related import (`AUTO_FOLLOW_RESUME_DELAY_MS`).
- Add a streaming-aware icon-only "Go to bottom" button inside the chat pane that appears when streaming content overflows the container (`showScrollToBottom` state and UI button with `data-testid="scroll-to-bottom-button"`).
- Use a CSS-safe selector helper (`escapeCssSelector`) when querying `[data-node-id]` elements and ensure `scrollToBottom` respects an `ignoreNextScrollRef` to avoid reacting to programmatic jumps.

### Testing
- Started the dev server with `npm run dev` and Next compiled successfully (local dev server reachable). (succeeded)
- Ran a Playwright script to navigate to the running app and capture a screenshot; the script executed and produced an artifact at `artifacts/auto-follow.png`. (succeeded)
- Unit tests (`npm test`) were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69725c5df398832b917c28478ec3b5c2)