### PR TITLE
Add configurable reply-to for workspace invite emails

### DIFF
--- a/env.example
+++ b/env.example
@@ -91,6 +91,7 @@ SUPABASE_SERVICE_ROLE_KEY=eyJ...  # server-only (migration/backfill), do not exp
 # Email notifications (workspace invites for existing users)
 RESEND_API_KEY=re_...
 RESEND_FROM_EMAIL=Threds <invite@threds.dev>
+RESEND_REPLY_TO_EMAIL=info@threds.dev
 
 # Public app origin used to build auth email redirects (signup confirm, password reset).
 # Examples:


### PR DESCRIPTION
## Summary
- add optional reply-to when sending workspace invite emails via Resend
- document the new reply-to env var

## Testing
- not run