### PR TITLE
Fix: keep branch colors stable across renames

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2161,7 +2161,15 @@ export function WorkspaceClient({
     return [...pinned, ...pendingGhosts, ...visible, ...hidden];
   }, [displayBranches]);
   const branchColorMap = useMemo(
-    () => buildBranchColorMap(sortedBranches.map((branch) => branch.name), trunkName),
+    () =>
+      buildBranchColorMap(
+        sortedBranches.map((branch) => ({
+          id: branch.id,
+          name: branch.name,
+          isTrunk: branch.isTrunk
+        })),
+        trunkName
+      ),
     [sortedBranches, trunkName]
   );
   const graphRequestKey = useMemo(() => sortedBranches.map((b) => b.name).sort().join('|'), [sortedBranches]);


### PR DESCRIPTION
### Motivation
- Branch colours were derived only from branch display names which caused palette shifts when a branch was renamed.
- Colours should remain stable across renames and still display correctly in existing places that look up by name.

### Description
- Add `BranchColorDescriptor` type and `resolveBranchKey` so a stable identifier (`id`) is preferred when computing a color with `hashBranchName`/`pickColorIndex`.
- Change `buildBranchColorMap` to accept `BranchColorDescriptor[]` and map colours to both `branch.name` and `branch.id` (when present), while preserving trunk detection and the existing collision fallback logic.
- Update `WorkspaceClient` to pass branch metadata (`id`, `name`, `isTrunk`) into `buildBranchColorMap` instead of just names so colours are tied to stable identifiers.
- Keep `getBranchColor` behaviour intact so existing lookups by name continue to work via the new map.

### Testing
- No automated tests were run as part of this change. The patch compiles locally (type edits limited to `branchColors.ts` and `WorkspaceClient.tsx`) and was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973713d72c0832bba675a25429033a1)