### PR TITLE
UI: indicate shared (non-owner) workspaces in rails

### DIFF
--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -5,7 +5,7 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { CreateProjectForm } from '@/src/components/projects/CreateProjectForm';
-import { ArchiveBoxArrowDownIcon, CheckIcon, ChevronRightIcon } from '@/src/components/workspace/HeroIcons';
+import { ArchiveBoxArrowDownIcon, CheckIcon, ChevronRightIcon, ShareIcon } from '@/src/components/workspace/HeroIcons';
 import { BlueprintIcon } from '@/src/components/ui/BlueprintIcon';
 import { AuthRailStatus } from '@/src/components/auth/AuthRailStatus';
 import { APP_NAME, storageKey } from '@/src/config/app';
@@ -147,6 +147,7 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                           <ul className="grid min-w-0 grid-cols-1 gap-2">
                             {recentProjects.map((project) => {
                               const isConfirming = confirming.has(project.id);
+                              const isSharedWorkspace = project.isOwner === false;
                               return (
                                 <li
                                   key={project.id}
@@ -163,27 +164,42 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                                         {dateFormatter.format(new Date(project.lastModified))}
                                       </div>
                                     </Link>
-                                    <button
-                                      type="button"
-                                      onClick={() => {
-                                        if (isConfirming) {
-                                          handleArchive(project.id);
-                                        } else {
-                                          setConfirming((prev) => new Set(prev).add(project.id));
-                                        }
-                                      }}
-                                      data-confirm-action="true"
-                                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
-                                        isConfirming
-                                          ? 'border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'
-                                          : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
-                                      }`}
-                                      aria-label={isConfirming ? 'Confirm archive' : 'Archive workspace'}
-                                      data-testid="archive-workspace"
-                                      data-project-id={project.id}
-                                    >
-                                      {isConfirming ? <CheckIcon className="h-4 w-4" /> : <ArchiveBoxArrowDownIcon className="h-4 w-4" />}
-                                    </button>
+                                    <div className="flex items-center gap-2">
+                                      {isSharedWorkspace ? (
+                                        <span
+                                          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-divider bg-white text-slate-500 shadow-sm"
+                                          title="Shared with you"
+                                          aria-label="Shared with you"
+                                        >
+                                          <ShareIcon className="h-4 w-4" />
+                                        </span>
+                                      ) : null}
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          if (isConfirming) {
+                                            handleArchive(project.id);
+                                          } else {
+                                            setConfirming((prev) => new Set(prev).add(project.id));
+                                          }
+                                        }}
+                                        data-confirm-action="true"
+                                        className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
+                                          isConfirming
+                                            ? 'border border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'
+                                            : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
+                                        }`}
+                                        aria-label={isConfirming ? 'Confirm archive' : 'Archive workspace'}
+                                        data-testid="archive-workspace"
+                                        data-project-id={project.id}
+                                      >
+                                        {isConfirming ? (
+                                          <CheckIcon className="h-4 w-4" />
+                                        ) : (
+                                          <ArchiveBoxArrowDownIcon className="h-4 w-4" />
+                                        )}
+                                      </button>
+                                    </div>
                                   </div>
                                 </li>
                               );
@@ -218,6 +234,7 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                             <ul className="grid min-w-0 grid-cols-1 gap-2">
                               {archivedProjects.map((project) => {
                                 const isConfirming = confirming.has(project.id);
+                                const isSharedWorkspace = project.isOwner === false;
                                 return (
                                   <li
                                     key={project.id}
@@ -232,31 +249,42 @@ export function HomePageContent({ projects, providerOptions, defaultProvider }: 
                                       >
                                         {project.name}
                                       </span>
-                                      <button
-                                        type="button"
-                                        onClick={() => {
-                                          if (isConfirming) {
-                                            handleUnarchive(project.id);
-                                          } else {
-                                            setConfirming((prev) => new Set(prev).add(project.id));
-                                          }
-                                        }}
-                                        data-confirm-action="true"
-                                        className={`ml-auto inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
-                                          isConfirming
-                                            ? 'border border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
-                                            : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
-                                        }`}
-                                        aria-label={isConfirming ? 'Confirm unarchive' : 'Unarchive workspace'}
-                                        data-testid="unarchive-workspace"
-                                        data-project-id={project.id}
-                                      >
-                                        {isConfirming ? (
-                                          <CheckIcon className="h-4 w-4" />
-                                        ) : (
-                                          <BlueprintIcon icon="unarchive" className="h-4 w-4" />
-                                        )}
-                                      </button>
+                                      <div className="ml-auto flex items-center gap-2">
+                                        {isSharedWorkspace ? (
+                                          <span
+                                            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-divider bg-white text-slate-500 shadow-sm"
+                                            title="Shared with you"
+                                            aria-label="Shared with you"
+                                          >
+                                            <ShareIcon className="h-4 w-4" />
+                                          </span>
+                                        ) : null}
+                                        <button
+                                          type="button"
+                                          onClick={() => {
+                                            if (isConfirming) {
+                                              handleUnarchive(project.id);
+                                            } else {
+                                              setConfirming((prev) => new Set(prev).add(project.id));
+                                            }
+                                          }}
+                                          data-confirm-action="true"
+                                          className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold shadow-sm transition ${
+                                            isConfirming
+                                              ? 'border border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                                              : 'border border-divider bg-white text-slate-700 hover:bg-primary/10'
+                                          }`}
+                                          aria-label={isConfirming ? 'Confirm unarchive' : 'Unarchive workspace'}
+                                          data-testid="unarchive-workspace"
+                                          data-project-id={project.id}
+                                        >
+                                          {isConfirming ? (
+                                            <CheckIcon className="h-4 w-4" />
+                                          ) : (
+                                            <BlueprintIcon icon="unarchive" className="h-4 w-4" />
+                                          )}
+                                        </button>
+                                      </div>
                                     </div>
                                   </li>
                                 );

--- a/src/components/workspace/HeroIcons.tsx
+++ b/src/components/workspace/HeroIcons.tsx
@@ -90,3 +90,7 @@ export function ConsoleIcon({ className }: IconProps) {
 export function PlusIcon({ className }: IconProps) {
   return <BlueprintIcon icon="folder-new" className={className} />;
 }
+
+export function ShareIcon({ className }: IconProps) {
+  return <BlueprintIcon icon="share" className={className} />;
+}

--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -52,6 +52,7 @@ import {
   PlusIcon,
   QuestionMarkCircleIcon,
   SearchIcon,
+  ShareIcon,
   Square2StackIcon,
   XMarkIcon
 } from './HeroIcons';
@@ -3628,12 +3629,24 @@ export function WorkspaceClient({
       <RailPageLayout
         renderRail={(ctx) => {
           railStateRef.current = ctx;
+          const isSharedWorkspace = project.isOwner === false;
           return (
             <div className="mt-6 flex h-full min-h-0 flex-col gap-6">
             {!ctx.railCollapsed ? (
               <div className="flex min-h-0 flex-1 flex-col gap-3">
                 <div className="rounded-2xl border border-divider/70 bg-white/80 px-3 py-2 shadow-sm">
-                  <div className="truncate text-xs font-semibold text-slate-800">{project.name}</div>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="truncate text-xs font-semibold text-slate-800">{project.name}</div>
+                    {isSharedWorkspace ? (
+                      <span
+                        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-divider/80 bg-white text-slate-500"
+                        title="Shared with you"
+                        aria-label="Shared with you"
+                      >
+                        <ShareIcon className="h-3.5 w-3.5" />
+                      </span>
+                    ) : null}
+                  </div>
                   <div className="truncate text-[11px] text-muted">{project.description ?? 'No description provided.'}</div>
                 </div>
                 <div className="flex min-h-0 flex-1 flex-col space-y-3 overflow-hidden">


### PR DESCRIPTION
### Motivation

- Provide a visual cue when a workspace has been shared to the current user so non-owners can see they are not the owner.
- Use the existing `ProjectMetadata.isOwner` signal to avoid additional RPCs or DB joins when deriving non-ownership.

### Description

- Added a reusable `ShareIcon` to `src/components/workspace/HeroIcons.tsx` for consistent icon rendering.
- Updated `src/components/home/HomePageContent.tsx` to derive `isSharedWorkspace = project.isOwner === false` and render the `ShareIcon` in recent and archived workspace rows next to the archive/unarchive control.
- Updated `src/components/workspace/WorkspaceClient.tsx` to compute `isSharedWorkspace = project.isOwner === false` and display the `ShareIcon` in the workspace rail header pill beside the workspace name.
- Updated imports and layout markup to keep spacing and aria/title attributes consistent (`title="Shared with you"`, `aria-label="Shared with you"`).

### Testing

- Started the dev server with `npm run dev` and it successfully served the app (Next.js ready). 
- Ran a Playwright script to load the home page and capture a screenshot, which completed successfully and produced an artifact. 
- No unit or integration test suites were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69726514d71c832b93780c151e70a77d)