### PR TITLE
fix: disable branching actions during streaming to avoid invalid split ids

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -4388,10 +4388,14 @@ export function WorkspaceClient({
                           onClick={() => {
                             setBranchActionError(null);
                             resetBranchQuestionState();
-                            setBranchSplitNodeId(latestPersistedVisibleNodeId);
+                            if (latestPersistedVisibleNodeId) {
+                              setBranchSplitNodeId(latestPersistedVisibleNodeId);
+                            } else {
+                              setBranchSplitNodeId(null);
+                            }
                             setShowNewBranchModal(true);
                           }}
-                          disabled={isCreating || isSwitching || branchActionDisabled || !latestPersistedVisibleNodeId}
+                          disabled={isCreating || isSwitching || branchActionDisabled}
                           className="inline-flex h-11 items-center gap-2 rounded-full border border-divider/80 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-primary/10 disabled:opacity-60"
                           aria-label="Show branch creator"
                           title={branchActionDisabled ? 'Branching is disabled while streaming' : undefined}


### PR DESCRIPTION
### Motivation
- The branch modal could capture the temporary `"streaming"` node as `branchSplitNodeId` if opened mid-stream, causing branch creation requests to send an invalid `fromNodeId` and fail. 
- The safest, most obvious UX is to prevent branching/editing actions while a response is streaming so transient nodes cannot be selected as split points.

### Description
- Added a `branchActionDisabled` prop to node UI and threaded it through `NodeBubble` and `ChatNodeRow` to allow per-message branch/edit actions to be disabled. 
- Disabled the per-message branch/edit button when `branchActionDisabled` is true and added a tooltip explaining the state. 
- Added an early guard in `openEditModal` to `pushToast('info', 'Branching is disabled while streaming.')` and return when `state.isStreaming`. 
- Disabled top-level branch creation button and all branch-creation form controls (rail + modal) while `state.isStreaming`, and passed `branchActionDisabled={state.isStreaming}` when rendering rows. 
- Prevents transient `streaming` sentinel from being recorded/used as a split node by blocking modal opens and submission paths during streaming.

### Testing
- Started the dev server with `npm run dev` to validate the app builds and the new runtime guards are reachable, which launched Next.js successfully. 
- Attempted a Playwright screenshot flow to validate the UI state, but the Chromium browser in the container crashed (`TargetClosedError` / SIGSEGV) so the screenshot step failed. 
- No automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697396df5060832bb13943db6f4848c0)