### PR TITLE
Prevent chat list flicker by anchoring streaming→persisted node handoff

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2730,8 +2730,15 @@ export function WorkspaceClient({
   const resolveStreamHoldTarget = useCallback(
     (list: NodeRecord[], targetBranch: string, anchorId: string | null, pendingTailId?: string | null) => {
       let anchorIndex = anchorId ? list.findIndex((node) => node.id === anchorId) : -1;
-      const currentTailId = list.length > 0 ? list[list.length - 1]!.id : null;
-      if (anchorIndex === -1 && pendingTailId && currentTailId === pendingTailId) {
+      let currentTailId: string | null = null;
+      for (let index = list.length - 1; index >= 0; index -= 1) {
+        const node = list[index];
+        if (node && node.type !== 'state') {
+          currentTailId = node.id;
+          break;
+        }
+      }
+      if (pendingTailId && currentTailId === pendingTailId) {
         return null;
       }
       const scope = anchorIndex >= 0 ? list.slice(anchorIndex + 1) : list;


### PR DESCRIPTION
### Motivation
- The UI flicker occurs because a transient `streaming` node is swapped for a newly persisted assistant node in separate renders, briefly producing duplicate or missing nodes and causing layout/scroll jumps. 
- The intent is to make the streaming→persisted transition atomic from the user's perspective so the list length and keys do not change visibly during refresh.

### Description
- Added a `streamAnchorIdRef` to record the last-visible persisted node when a stream starts and set it from `sendDraft` / `sendQuestionWithStream` so the handoff can resolve deterministically. 
- Changed stream completion ordering so final streamed content is stashed into `streamHoldPending` before calling `refreshHistory()`/`mutateArtefact()`, and only cleared after resolving whether a held mapping is required. 
- Implemented `resolveStreamHoldTarget(list, branch, anchorId)` to find the correct persisted assistant node relative to the anchor and apply held content directly onto that node via a transient `streamHold`, avoiding a separate `streaming` list entry. 
- Suppressed rendering of the transient `streaming` node when a `streamHold` or pending resolved target exists, and reset anchors/refs when hold data clears or the branch changes. 
- All changes are in `src/components/workspace/WorkspaceClient.tsx` and focus on mapping streamed content onto the persisted node to avoid list-length/key swaps.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754d62f320832bb058c8a8c362e108)