### PR TITLE
Fix composer corner radius when expanding

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -835,6 +835,7 @@ export function WorkspaceClient({
   const [graphMode, setGraphMode] = useState<'nodes' | 'collapsed' | 'starred'>('collapsed');
   const [composerPadding, setComposerPadding] = useState(128);
   const [composerCollapsed, setComposerCollapsed] = useState(false);
+  const [composerCornerRadius, setComposerCornerRadius] = useState<number | null>(null);
   const isGraphVisible = !insightCollapsed && insightTab === 'graph';
   const collapseInsights = useCallback(() => {
     savedChatPaneWidthRef.current = chatPaneWidth;
@@ -855,6 +856,7 @@ export function WorkspaceClient({
 
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const composerBasePaddingRef = useRef<number>(composerPadding);
+  const composerCornerRadiusRef = useRef<number | null>(null);
   const [composerMinHeight, setComposerMinHeight] = useState<number | null>(null);
   const [composerMaxHeight, setComposerMaxHeight] = useState<number | null>(null);
 
@@ -2008,6 +2010,22 @@ export function WorkspaceClient({
     textarea.style.height = `${nextHeight}px`;
   }, [composerMaxHeight, composerMinHeight]);
 
+  const updateComposerCornerRadius = useCallback(() => {
+    const composer = composerRef.current;
+    const textarea = composerTextareaRef.current;
+    if (!composer || !textarea) return;
+    const minHeight = composerMinHeight;
+    if (!minHeight) return;
+    const composerHeight = composer.getBoundingClientRect().height;
+    const textareaHeight = textarea.getBoundingClientRect().height;
+    const delta = Math.max(0, composerHeight - textareaHeight);
+    const baseHeight = minHeight + delta;
+    const nextRadius = Math.ceil(baseHeight / 2);
+    if (composerCornerRadiusRef.current === nextRadius) return;
+    composerCornerRadiusRef.current = nextRadius;
+    setComposerCornerRadius(nextRadius);
+  }, [composerMinHeight]);
+
   const updateBaseComposerPadding = useCallback(() => {
     const composer = composerRef.current;
     if (!composer) return;
@@ -2023,6 +2041,10 @@ export function WorkspaceClient({
   useLayoutEffect(() => {
     resizeComposer();
   }, [draft, resizeComposer]);
+
+  useLayoutEffect(() => {
+    updateComposerCornerRadius();
+  }, [draft, updateComposerCornerRadius]);
 
   useEffect(() => {
     if (!state.error || (!optimisticDraftRef.current && !questionDraftRef.current)) return;
@@ -2418,13 +2440,14 @@ export function WorkspaceClient({
     const handleResize = () => {
       updateComposerMetrics();
       resizeComposer();
+      updateComposerCornerRadius();
       if (!draft.trim()) {
         updateBaseComposerPadding();
       }
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [draft, resizeComposer, updateBaseComposerPadding, updateComposerMetrics]);
+  }, [draft, resizeComposer, updateBaseComposerPadding, updateComposerMetrics, updateComposerCornerRadius]);
 
 
   useEffect(() => {
@@ -5422,7 +5445,10 @@ export function WorkspaceClient({
               >
                 <div
                   ref={composerRef}
-                  className="flex items-center gap-2 rounded-full border border-divider bg-white px-3 py-2 shadow-composer"
+                  className="flex items-center gap-2 border border-divider bg-white px-3 py-2 shadow-composer"
+                  style={{
+                    borderRadius: composerCornerRadius ? `${composerCornerRadius}px` : '9999px'
+                  }}
                 >
                   <div className="flex items-center gap-2">
                     <button


### PR DESCRIPTION
### Motivation
- The composer’s rounded corners scaled with its height (height/2), producing an exaggerated pill shape as it expanded; the UI should preserve the corner radius used at the minimum composer height so expansion looks consistent.

### Description
- Add `composerCornerRadius` state and `composerCornerRadiusRef` to `src/components/workspace/WorkspaceClient.tsx` to track a stable corner radius derived from the minimum textarea metrics.
- Implement `updateComposerCornerRadius` to measure composer and textarea heights, compute a base radius from the minimum height, and set it only when it changes.
- Hook radius updates into layout and resize flows (`useLayoutEffect` on `draft` and `updateComposerCornerRadius`, and window `resize` handler) so the radius remains stable while expanding.
- Apply the computed radius to the composer container via inline `style` with a fallback to `'9999px'` for the previous fully-rounded appearance.

### Testing
- Started the dev server (`npm run dev`) which compiled and served the app successfully (Next.js reported Ready).
- Ran a Playwright script to load the running app and capture a screenshot (`artifacts/composer-radius.png`), which completed successfully and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a69ef62c832bbeb17b43289ef5f3)