### PR TITLE
Add password reveal toggles to sign in and registration forms

### DIFF
--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { signInWithPassword, signUpWithPassword } from './actions';
 import Link from 'next/link';
 import { useCommandEnterSubmit } from '@/src/hooks/useCommandEnterSubmit';
+import { BlueprintIcon } from '@/src/components/ui/BlueprintIcon';
 import { PASSWORD_MIN_LENGTH, PASSWORD_POLICY_HINT } from '@/src/utils/passwordPolicy';
 
 function SubmitButton({ label }: { label: string }) {
@@ -47,6 +48,8 @@ export function LoginForm({
   const [signUpState, signUpAction] = useFormState(signUpWithPassword, initialState);
   const [mode, setMode] = useState<'signUp' | 'signIn'>(initialMode);
   const [emailValue, setEmailValue] = useState(initialEmail ?? '');
+  const [showSignInPassword, setShowSignInPassword] = useState(false);
+  const [showSignUpPassword, setShowSignUpPassword] = useState(false);
   const handleSignInCommandEnter = useCommandEnterSubmit();
   const handleSignUpCommandEnter = useCommandEnterSubmit();
 
@@ -94,13 +97,23 @@ export function LoginForm({
           </label>
           <label className="block">
             <span className="text-sm font-medium text-slate-800">Password</span>
-            <input
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none ring-slate-900/20 focus:ring-2"
-              name="password"
-              type="password"
-              autoComplete="current-password"
-              required
-            />
+            <div className="relative mt-1">
+              <input
+                className="w-full rounded-md border border-slate-300 px-3 py-2 pr-10 text-sm outline-none ring-slate-900/20 focus:ring-2"
+                name="password"
+                type={showSignInPassword ? 'text' : 'password'}
+                autoComplete="current-password"
+                required
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-2 flex items-center justify-center text-slate-600 hover:text-slate-900"
+                onClick={() => setShowSignInPassword((current) => !current)}
+                aria-label={showSignInPassword ? 'Hide password' : 'Show password'}
+              >
+                <BlueprintIcon icon={showSignInPassword ? 'eye-off' : 'eye-open'} className="h-4 w-4" />
+              </button>
+            </div>
           </label>
 
           {activeError ? <p className="text-sm text-red-700">{activeError}</p> : null}
@@ -141,19 +154,27 @@ export function LoginForm({
           </label>
           <label className="block">
             <span className="text-sm font-medium text-slate-800">Password</span>
-            <input
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none ring-slate-900/20 focus:ring-2"
-              name="password"
-              type="password"
-              autoComplete="new-password"
-              minLength={PASSWORD_MIN_LENGTH}
-              pattern={`(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{${PASSWORD_MIN_LENGTH},}`}
-              title={PASSWORD_POLICY_HINT}
-              required
-            />
-            <span className="mt-1 block text-xs text-slate-600">
-              {PASSWORD_POLICY_HINT}
-            </span>
+            <div className="relative mt-1">
+              <input
+                className="w-full rounded-md border border-slate-300 px-3 py-2 pr-10 text-sm outline-none ring-slate-900/20 focus:ring-2"
+                name="password"
+                type={showSignUpPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                minLength={PASSWORD_MIN_LENGTH}
+                pattern={`(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{${PASSWORD_MIN_LENGTH},}`}
+                title={PASSWORD_POLICY_HINT}
+                required
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-2 flex items-center justify-center text-slate-600 hover:text-slate-900"
+                onClick={() => setShowSignUpPassword((current) => !current)}
+                aria-label={showSignUpPassword ? 'Hide password' : 'Show password'}
+              >
+                <BlueprintIcon icon={showSignUpPassword ? 'eye-off' : 'eye-open'} className="h-4 w-4" />
+              </button>
+            </div>
+            <span className="mt-1 block text-xs text-slate-600">{PASSWORD_POLICY_HINT}</span>
           </label>
 
           {activeError ? <p className="text-sm text-red-700">{activeError}</p> : null}


### PR DESCRIPTION
### Motivation
- Improve UX by letting users reveal their typed password to verify input when signing in or creating an account.

### Description
- Updated `app/login/LoginForm.tsx` to add password visibility toggle controls for both sign-in and sign-up password inputs.
- Imported `BlueprintIcon` and added two pieces of state: `showSignInPassword` and `showSignUpPassword` to control visibility independently.
- Replaced plain password inputs with a `relative` wrapper that includes a button rendering `BlueprintIcon` (`eye-open` / `eye-off`) and toggles the input `type` between `password` and `text` while preserving original attributes and accessibility `aria-label`s.
- Kept password fields obscured by default and preserved the password policy UI and validation attributes for the sign-up flow.

### Testing
- Launched the app with `npm run dev` and confirmed the `/login` page compiled and returned `200` (Next dev compilation succeeded).
- Ran a Playwright script to navigate to `http://127.0.0.1:3000/login` and capture a screenshot of the login form, and the script completed successfully (screenshot artifact created).
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ce1524d0832bb272e8aef1c7ce20)