### PR TITLE
Lighten markdown code block styling and update copy button colors

### DIFF
--- a/src/components/workspace/MarkdownWithCopy.tsx
+++ b/src/components/workspace/MarkdownWithCopy.tsx
@@ -46,7 +46,7 @@ const CodeBlock = ({ className, children }: CodeProps) => {
 
   return (
     <div className="group relative mt-4">
-      <pre className="overflow-x-auto rounded-xl bg-slate-900/90 p-4 text-sm leading-6 text-slate-50 shadow-sm">
+      <pre className="overflow-x-auto rounded-xl border border-slate-200 bg-slate-100/80 p-4 text-sm leading-6 text-slate-900 shadow-sm">
         <code className={className}>{children}</code>
       </pre>
       <button
@@ -55,16 +55,16 @@ const CodeBlock = ({ className, children }: CodeProps) => {
           void handleCopy();
         }}
         aria-label={copied ? 'Code copied' : 'Copy code block'}
-        className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-slate-700/70 bg-slate-800/80 px-3 py-1 text-xs font-semibold text-slate-100 opacity-100 transition hover:bg-slate-700/90 focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-2 focus:ring-offset-slate-900"
+        className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white/90 px-3 py-1 text-xs font-semibold text-slate-700 opacity-100 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-2 focus:ring-offset-slate-100"
       >
         {copied ? (
           <>
-            <CheckIcon className="h-4 w-4 text-emerald-300" />
+            <CheckIcon className="h-4 w-4 text-emerald-600" />
             <span>Copied</span>
           </>
         ) : (
           <>
-            <Square2StackIcon className="h-4 w-4 text-slate-200" />
+            <Square2StackIcon className="h-4 w-4 text-slate-600" />
             <span>Copy</span>
           </>
         )}


### PR DESCRIPTION
### Motivation
- The markdown rendering box was very dark and high-contrast compared to the rest of the app, so the intent is to provide a lighter (10–20% gray) background with darker text for consistency. 
- The copy button and icons needed adjusted hues to maintain contrast on the lighter background.

### Description
- Updated code block container styles in `src/components/workspace/MarkdownWithCopy.tsx` to use a light background, subtle border, and dark text (`bg-slate-100/80`, `border-slate-200`, `text-slate-900`).
- Adjusted the copy button palette to lighter surfaces and darker text and border (`border-slate-300`, `bg-white/90`, `text-slate-700`).
- Tweaked icon colors for the copy state to `text-emerald-600` and idle icon to `text-slate-600` for better contrast.

### Testing
- Started the dev server with `npm run dev` and Next compiled the app successfully. 
- Captured a full-page screenshot of the updated UI using a Playwright script which completed and produced an artifact screenshot. 
- No unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b6dd1084832b9896936b93485196)