### PR TITLE
Fix quote reply selection scoping per message

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -218,7 +218,7 @@ const NodeBubble: FC<{
   showOpenAiThinkingNote?: boolean;
   branchActionDisabled?: boolean;
   quoteSelectionText?: string;
-  onQuoteReply?: (messageText: string, selectionText?: string) => void;
+  onQuoteReply?: (nodeId: string, messageText: string, selectionText?: string) => void;
 }> = ({
   node,
   muted = false,
@@ -606,7 +606,7 @@ const NodeBubble: FC<{
           {canQuoteReply ? (
             <button
               type="button"
-              onClick={() => onQuoteReply(messageText, quoteSelectionText)}
+              onClick={() => onQuoteReply(node.id, messageText, quoteSelectionText)}
               disabled={branchActionDisabled}
               className={`rounded-full px-2 py-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 ${
                 quoteSelectionActive
@@ -676,7 +676,7 @@ const ChatNodeRow: FC<{
   showBranchSplit?: boolean;
   branchActionDisabled?: boolean;
   quoteSelectionText?: string;
-  onQuoteReply?: (messageText: string, selectionText?: string) => void;
+  onQuoteReply?: (nodeId: string, messageText: string, selectionText?: string) => void;
 }> = ({
   node,
   trunkName,
@@ -1985,8 +1985,9 @@ export function WorkspaceClient({
 
   const expandComposer = useCallback(() => toggleComposerCollapsed(false), [toggleComposerCollapsed]);
   const handleQuoteReply = useCallback(
-    (messageText: string, selectionText?: string) => {
-      const trimmedSelection = selectionText?.trim() ?? '';
+    (nodeId: string, messageText: string, selectionText?: string) => {
+      const scopedSelection = getSelectionForNode(nodeId);
+      const trimmedSelection = scopedSelection || selectionText?.trim() || '';
       const sourceText = trimmedSelection || messageText;
       const normalized = sourceText.replace(/\r\n/g, '\n');
       const quoted = normalized
@@ -2012,7 +2013,7 @@ export function WorkspaceClient({
         }
       }, 0);
     },
-    [composerCollapsed, expandComposer]
+    [composerCollapsed, expandComposer, getSelectionForNode]
   );
   const toggleAllWorkspacePanels = useCallback(() => {
     const railState = railStateRef.current;


### PR DESCRIPTION
### Motivation
- Quote-reply could inject text from the wrong message when a selection existed in a later assistant message; the intent is to ensure quoted text is always taken from the clicked message (its parent node). 

### Description
- Change the quote-reply handler signature to accept a node id (`onQuoteReply(nodeId, messageText, selectionText?)`).
- Wire the `NodeBubble` and `ChatNodeRow` buttons to pass `node.id` through the `onQuoteReply` call in `src/components/workspace/WorkspaceClient.tsx`.
- Update `handleQuoteReply` to prefer a scoped selection via `getSelectionForNode(nodeId)` and fall back to the provided selection or full message text, and add `getSelectionForNode` to the callback deps.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ebb94d5c832b9dccfe4fddb462a6)