### PR TITLE
Docs: add gh pr create body formatting tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,12 @@ Issue creation process:
 ## Supabase migration files
  - The file MUST be named in the format YYYYMMDDHHmmss_short_description.sql with proper casing for months, minutes, and seconds in UTC time.
 
-## Git Commits
+## Git Commits & PRs
 - When writing commit messages, always note the type of change (fix, chore, etc.) and then write a 1-2 sentence summary as well as detailed bullet points of the changes made. You can be thorough here.
+
+- When using gh pr create -b, pass a real multi‑line string, not \n literals. The safest way is:
+    - Use $'...' and real \n escapes (Bash/Zsh), or
+    - Put the body in a temp file and use -F file.md.
 
 ## E2E Testing with Playwright
 When embarking on Playwright configuration (design, testing, debugging), please consult PM_DOCS/PLAYWRIGHT_SOP.md before starting.


### PR DESCRIPTION
## Summary
- document correct multi-line body formatting for gh pr create
- prevent literal 
 showing up in PR descriptions

## Details
- add guidance to AGENTS.md under "Git Commits & PRs"
- suggest using $'...' strings or -F file.md for multi-line bodies

## Testing
- not applicable