### PR TITLE
chore: rename production environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/master' && 'prod' || 'preview' }}
+    environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Never assume `ref.name` is an FK; resolve display labels from refs.
 
 ## Feature branches
-master and dev branches are protected. Create a feature branch to work using the format codex/{yyyyMMdd}/a-clear-descriptive-title
+master and dev branches are protected. Create a feature branch to work using the format codex/{yyyy-MM-dd}/a-clear-descriptive-title
 
 ## Product Management
 We plan and track progress in PM_DOCS/


### PR DESCRIPTION
Update Actions environment naming for master pushes and adjust branch-format guidance.

- rename workflow environment from prod to production
- document hyphenated date format in AGENTS branch naming