### PR TITLE
fix: quote-reply should end with double newline

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -2544,7 +2544,8 @@ export function WorkspaceClient({
         .split('\n')
         .map((line) => (line ? `> ${line}` : '>'))
         .join('\n');
-      setDraft((prev) => (prev ? `${prev}\n\n${quoted}` : quoted));
+      const quotedBlock = `${quoted}\n\n`;
+      setDraft((prev) => (prev ? `${prev}\n\n${quotedBlock}` : quotedBlock));
       if (composerCollapsed) {
         expandComposer();
       }


### PR DESCRIPTION
### Motivation
- The quote-reply composer previously inserted a quoted block that did not guarantee a trailing blank line, causing follow-up text to appear on the same line as the quote; replies should end with two newlines so there is a blank line after the quote.

### Description
- Update `handleQuoteReply` in `src/components/workspace/WorkspaceClient.tsx` to append an explicit trailing `\n\n` to the generated quoted block and use that `quotedBlock` when calling `setDraft` so the composer text always ends with a double newline.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb5a1743c832b89e9cc3ee526665d)