### PR TITLE
Fix Supabase lint warnings and FK indexes

### DIFF
--- a/supabase/migrations/20260201212626_fix_supabase_lints.sql
+++ b/supabase/migrations/20260201212626_fix_supabase_lints.sql
@@ -1,0 +1,41 @@
+-- Fix Supabase lints for function search_path and RLS policies.
+
+alter function public.rt_is_project_owner(uuid) set search_path = 'public';
+
+-- Provide explicit RLS policies to satisfy linting while keeping tables closed by default.
+
+drop policy if exists "access_codes_no_access" on public.access_codes;
+create policy "access_codes_no_access" on public.access_codes
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "email_allowlist_no_access" on public.email_allowlist;
+create policy "email_allowlist_no_access" on public.email_allowlist
+  for all
+  to public
+  using (false)
+  with check (false);
+
+drop policy if exists "waitlist_requests_no_access" on public.waitlist_requests;
+create policy "waitlist_requests_no_access" on public.waitlist_requests
+  for all
+  to public
+  using (false)
+  with check (false);
+
+-- Fix auth RLS initplan warning by materializing auth.uid().
+
+drop policy if exists "project_invites_select_owner" on public.project_invites;
+create policy "project_invites_select_owner" on public.project_invites
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.projects p
+      where p.id = project_invites.project_id
+        and p.owner_user_id = (select auth.uid())
+    )
+  );

--- a/supabase/migrations/20260201213118_add_fk_indexes.sql
+++ b/supabase/migrations/20260201213118_add_fk_indexes.sql
@@ -1,0 +1,34 @@
+-- Add indexes to cover foreign keys flagged by Supabase linter.
+
+create index if not exists artefact_drafts_ref_id_idx
+  on public.artefact_drafts (ref_id);
+
+create index if not exists artefacts_commit_id_idx
+  on public.artefacts (commit_id);
+
+create index if not exists artefacts_ref_id_idx
+  on public.artefacts (ref_id);
+
+create index if not exists commit_order_commit_id_idx
+  on public.commit_order (commit_id);
+
+create index if not exists commit_order_ref_id_idx
+  on public.commit_order (ref_id);
+
+create index if not exists nodes_commit_id_idx
+  on public.nodes (commit_id);
+
+create index if not exists nodes_created_on_ref_id_idx
+  on public.nodes (created_on_ref_id);
+
+create index if not exists nodes_merge_from_ref_id_idx
+  on public.nodes (merge_from_ref_id);
+
+create index if not exists project_user_prefs_current_ref_id_idx
+  on public.project_user_prefs (current_ref_id);
+
+create index if not exists ref_leases_ref_id_idx
+  on public.ref_leases (ref_id);
+
+create index if not exists stars_node_id_idx
+  on public.stars (node_id);


### PR DESCRIPTION
- fix lint warnings for search_path, RLS default policies, and initplan auth usage
- add FK covering indexes flagged by Supabase linter

Notes:
- default-deny RLS policies keep waitlist tables closed by default
- RLS policy for project_invites now materializes auth.uid() for initplan optimization