### PR TITLE
Document desktop env setup and fix local auth mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ The Electron shell boots a local Next.js server and opens a native window.
 
 Desktop loads `.env.desktop` and then `.env.local` (excluding Supabase keys), so local Postgres is the default path.
 
+### Desktop env setup
+
+- Use `env.desktop.example` as the starting point (copy to `.env.desktop`).
+- Desktop loads `.env.desktop` first, then `.env.local` (Supabase keys are skipped at runtime).
+- `LOCAL_PG_URL` is stored in the desktop config file at `~/Library/Application Support/<APP_NAME>/config.json`
+  (if missing, the app prompts or uses a default on first run).
+- For packaging with local PG, avoid Supabase settings in the build environment or override them explicitly.
+
 ## Repository Map
 
 - `app/` Next.js route handlers and pages.

--- a/app/admin/waitlist/page.tsx
+++ b/app/admin/waitlist/page.tsx
@@ -9,6 +9,7 @@ import { AdminSubmitButton } from './AdminSubmitButton';
 import { CommandEnterForm } from '@/src/components/forms/CommandEnterForm';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export default async function AdminWaitlistPage() {
   await requireAdminUser();

--- a/app/auth/invite/route.ts
+++ b/app/auth/invite/route.ts
@@ -7,6 +7,7 @@ import { getStoreConfig } from '@/src/server/storeConfig';
 import { requireUser } from '@/src/server/auth';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   try {

--- a/env.desktop.example
+++ b/env.desktop.example
@@ -1,0 +1,24 @@
+# Desktop app environment (minimal, local PG)
+# Copy to .env.desktop and adjust as needed.
+
+# App metadata
+NEXT_PUBLIC_APP_NAME=threds
+NEXT_PUBLIC_APP_ID=threds
+
+# Store selection (desktop defaults to pg + local adapter)
+RT_STORE=pg
+RT_PG_ADAPTER=local
+RT_PG_BOOTSTRAP=1
+
+# Optional: local projects root (defaults to user data dir/projects)
+# RESEARCHTREE_PROJECTS_ROOT=data/projects
+
+# Optional: waitlist enforcement (off by default)
+RT_WAITLIST_ENFORCE=false
+
+# Optional: dev-only provider config
+# LLM_DEFAULT_PROVIDER=mock
+# LLM_ENABLE_OPENAI=false
+# LLM_ENABLE_GEMINI=false
+# LLM_ENABLE_ANTHROPIC=false
+

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,11 +5,11 @@ import type { User } from '@supabase/supabase-js';
 import { unauthorized } from '@/src/server/http';
 import { createSupabaseServerClient } from '@/src/server/supabase/server';
 import { assertLocalPgModeConfig, isLocalPgMode } from '@/src/server/pgMode';
-import { LOCAL_PG_USER_ID } from '@/src/server/localPgConfig';
+import { LOCAL_PG_USER_EMAIL, LOCAL_PG_USER_ID } from '@/src/server/localPgConfig';
 
 const LOCAL_USER: User = {
   id: LOCAL_PG_USER_ID,
-  email: 'local@device',
+  email: LOCAL_PG_USER_EMAIL,
   app_metadata: {},
   user_metadata: {},
   aud: 'local',

--- a/src/server/localPgBootstrap.ts
+++ b/src/server/localPgBootstrap.ts
@@ -5,7 +5,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Pool } from 'pg';
-import { getLocalPgConnectionStrings, LOCAL_PG_USER_ID } from '@/src/server/localPgConfig';
+import { getLocalPgConnectionStrings, LOCAL_PG_USER_EMAIL, LOCAL_PG_USER_ID } from '@/src/server/localPgConfig';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -69,7 +69,7 @@ async function ensureLocalSchemas(pool: Pool): Promise<void> {
     on conflict (id) do update
       set email = excluded.email
   `,
-    [LOCAL_PG_USER_ID, 'local@example.com']
+    [LOCAL_PG_USER_ID, LOCAL_PG_USER_EMAIL]
   );
   await pool.query(
     `
@@ -89,7 +89,7 @@ async function ensureLocalSchemas(pool: Pool): Promise<void> {
     language sql
     stable
     as $$
-      select jsonb_build_object('email', 'local@example.com')
+      select jsonb_build_object('email', '${LOCAL_PG_USER_EMAIL}')
     $$;
   `
   );

--- a/src/server/localPgConfig.ts
+++ b/src/server/localPgConfig.ts
@@ -3,6 +3,7 @@
 
 const DEFAULT_LOCAL_PG_DB = 'threds';
 export const LOCAL_PG_USER_ID = '00000000-0000-0000-0000-000000000001';
+export const LOCAL_PG_USER_EMAIL = 'local@example.com';
 const DEFAULT_LOCAL_PG_USER = process.env.USER ?? process.env.USERNAME ?? process.env.LOGNAME ?? '';
 
 function ensureUsername(url: URL): void {


### PR DESCRIPTION
## Summary
- add a minimal env.desktop.example and README desktop env notes
- centralize the local PG user email to avoid auth mismatches
- mark invite and admin waitlist routes as dynamic to avoid build prerender errors

## Testing
- not run (desktop smoke tested by user)
