### PR TITLE
Follow-up: ensure markdown tables scroll horizontally in chat

### DIFF
--- a/src/components/workspace/MarkdownWithCopy.tsx
+++ b/src/components/workspace/MarkdownWithCopy.tsx
@@ -22,6 +22,8 @@ type CodeProps = {
   children?: React.ReactNode;
 };
 
+type TableProps = React.ComponentPropsWithoutRef<'table'>;
+
 const InlineCode = ({ className, children }: CodeProps) => {
   const mergedClassName = [
     'rounded-md bg-slate-100 px-1.5 py-0.5 text-[0.85em] font-semibold text-slate-700',
@@ -110,11 +112,22 @@ const PreBlock = ({ children }: PreProps) => {
   return <CodeBlock className={className}>{codeChildren}</CodeBlock>;
 };
 
+const MarkdownTable = ({ className, children, ...props }: TableProps) => {
+  return (
+    <div className="my-4 max-w-full overflow-x-auto">
+      <table {...props} className={['w-max min-w-full', className].filter(Boolean).join(' ')}>
+        {children}
+      </table>
+    </div>
+  );
+};
+
 export const MarkdownWithCopy = ({ content, className }: MarkdownWithCopyProps) => {
   const components = useMemo<Components>(
     () => ({
       code: (props) => <InlineCode {...props} />,
-      pre: (props) => <PreBlock {...props} />
+      pre: (props) => <PreBlock {...props} />,
+      table: (props) => <MarkdownTable {...props} />
     }),
     []
   );

--- a/tests/client/MarkdownWithCopy.test.tsx
+++ b/tests/client/MarkdownWithCopy.test.tsx
@@ -41,4 +41,24 @@ describe('MarkdownWithCopy', () => {
     await user.click(buttons[1]!);
     expect(copyTextToClipboardMock).toHaveBeenCalledWith('const beta = 2;');
   });
+
+  it('wraps markdown tables in a horizontal overflow container', () => {
+    render(
+      <div className="prose prose-sm prose-slate">
+        <MarkdownWithCopy
+          content={`| Name | Notes |
+| --- | --- |
+| alpha | this is a fairly long value that should stay inside chat |
+| beta | another long value |
+`}
+        />
+      </div>
+    );
+
+    const table = screen.getByRole('table');
+    const scrollContainer = table.parentElement;
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer).toHaveClass('max-w-full', 'overflow-x-auto');
+    expect(table).toHaveClass('w-max', 'min-w-full');
+  });
 });


### PR DESCRIPTION
### Motivation
- Markdown tables wider than the chat container were overflowing and being cropped instead of allowing horizontal scrolling.
- Messages that contain large tables must remain visually contained within the message bubble and be scrollable so content is accessible.

### Description
- Added a `MarkdownTable` renderer to `src/components/workspace/MarkdownWithCopy.tsx` that wraps rendered `<table>` elements in a container with `my-4 max-w-full overflow-x-auto` so tables can scroll horizontally when needed.
- Applied sizing classes `w-max min-w-full` to the rendered `<table>` to preserve normal table layout while enabling overflow only when required.
- Registered the custom table renderer in the `ReactMarkdown` `components` map inside `MarkdownWithCopy` so all markdown tables use the overflow wrapper.
- Added a unit test `tests/client/MarkdownWithCopy.test.tsx` that verifies rendered markdown tables are wrapped by the scroll container and have the expected classes.

### Testing
- Ran the focused unit test with `npm test -- tests/client/MarkdownWithCopy.test.tsx`, and it passed (2 tests, both passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987bc837d90832b9654cf980b703eef)