### PR TITLE
fix: correct p95 percentile index in workspace perf telemetry

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -186,7 +186,7 @@ const getWorkspacePerfDebugState = (): WorkspacePerfDebugState | null => {
 const flushWorkspacePerfDebugBurst = (state: WorkspacePerfDebugState) => {
   if (!state.keypressToPaintMs.length) return;
   const sorted = [...state.keypressToPaintMs].sort((a, b) => a - b);
-  const p95Index = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95));
+  const p95Index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * 0.95) - 1));
   const p95 = sorted[p95Index] ?? 0;
   const avg = state.keypressToPaintMs.reduce((acc, value) => acc + value, 0) / state.keypressToPaintMs.length;
   console.info('[perf-debug] burst', {


### PR DESCRIPTION
### Motivation
- Reviewer noted the p95 calculation in perf logging over-selected high-order samples, inflating reported `p95KeypressToPaintMs` and breaking baseline comparisons.
- Ensure telemetry reports the actual 95th-percentile sample so collected baselines are reliable for perf analysis.

### Description
- Replaced the floor-based index `Math.floor(n * 0.95)` with a ceil-based percentile index `Math.ceil(n * 0.95) - 1` and added lower/upper clamping to keep the index in-bounds in `flushWorkspacePerfDebugBurst`.
- Change localized to a single line in `src/components/workspace/WorkspaceClient.tsx` and preserves existing sorting, averaging, and logging behavior.
- Committed the fix on branch `codex/2026-02-09/fix-p95-percentile-index` and opened a follow-up PR on top of the original instrumentation changes.

### Testing
- Ran type checking with `npm run typecheck` and it passed.
- Performed a code inspection to verify only the percentile index selection was modified and logging/output shape remains unchanged.
- No runtime behavioral tests were changed; this is a deterministic, single-line telemetry math fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a261c7234832b8e95b9d2f6adda1c)