### PR TITLE
[BUG Follow-up] Extend clickjacking protections to all auth pages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -74,6 +74,25 @@ function isPublicPath(pathname: string): boolean {
   return false;
 }
 
+function shouldApplyClickjackingProtection(pathname: string): boolean {
+  if (pathname === '/login') return true;
+  if (pathname === '/check-email') return true;
+  if (pathname === '/forgot-password') return true;
+  if (pathname === '/reset-password') return true;
+  if (pathname.startsWith('/auth/')) return true;
+  return false;
+}
+
+function withClickjackingHeaders(pathname: string, response: NextResponse): NextResponse {
+  if (!shouldApplyClickjackingProtection(pathname)) {
+    return response;
+  }
+
+  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('Content-Security-Policy', "frame-ancestors 'none'");
+  return response;
+}
+
 function sanitizeRedirectTo(input: string | null): string | null {
   if (!input) return null;
   if (!input.startsWith('/')) return null;
@@ -202,7 +221,7 @@ export async function middleware(request: NextRequest) {
 
   const pathname = request.nextUrl.pathname;
   if (maintenanceEnabled && adminUserIds.size === 0) {
-    return buildMaintenanceResponse(request);
+    return withClickjackingHeaders(pathname, buildMaintenanceResponse(request));
   }
 
   if (!maintenanceEnabled && pathname.startsWith('/api')) {
@@ -212,20 +231,20 @@ export async function middleware(request: NextRequest) {
   const anySupabaseEnv = hasAnySupabaseEnv();
   if (isExplicitLocalMode() && !anySupabaseEnv) {
     if (maintenanceEnabled) {
-      return buildMaintenanceResponse(request);
+      return withClickjackingHeaders(pathname, buildMaintenanceResponse(request));
     }
-    return NextResponse.next();
+    return withClickjackingHeaders(pathname, NextResponse.next());
   }
 
   const supabaseEnv = getSupabaseEnv();
   if (!supabaseEnv) {
     if (maintenanceEnabled) {
-      return buildMaintenanceResponse(request);
+      return withClickjackingHeaders(pathname, buildMaintenanceResponse(request));
     }
     if (anySupabaseEnv) {
-      return new NextResponse('Supabase env is incomplete', { status: 500 });
+      return withClickjackingHeaders(pathname, new NextResponse('Supabase env is incomplete', { status: 500 }));
     }
-    return NextResponse.next();
+    return withClickjackingHeaders(pathname, NextResponse.next());
   }
 
   let response = NextResponse.next({
@@ -253,7 +272,7 @@ export async function middleware(request: NextRequest) {
   if (maintenanceEnabled) {
     const userId = user?.id ?? null;
     if (!userId || !adminUserIds.has(userId)) {
-      return buildMaintenanceResponse(request);
+      return withClickjackingHeaders(pathname, buildMaintenanceResponse(request));
     }
   }
 
@@ -265,11 +284,11 @@ export async function middleware(request: NextRequest) {
     const redirectTo = sanitizeRedirectTo(request.nextUrl.searchParams.get('redirectTo')) ?? '/';
     const redirectUrl = new URL(redirectTo, request.url);
     response = withSupabaseCookies(response, NextResponse.redirect(redirectUrl));
-    return response;
+    return withClickjackingHeaders(pathname, response);
   }
 
   if (isPublicPath(pathname)) {
-    return response;
+    return withClickjackingHeaders(pathname, response);
   }
 
   if (!user) {
@@ -281,7 +300,7 @@ export async function middleware(request: NextRequest) {
     response = withSupabaseCookies(response, NextResponse.redirect(redirectUrl));
   }
 
-  return response;
+  return withClickjackingHeaders(pathname, response);
 }
 
 export const config = {

--- a/tests/server/middleware.test.ts
+++ b/tests/server/middleware.test.ts
@@ -42,6 +42,20 @@ describe('middleware auth redirects', () => {
     mocks.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
     const res = await middleware(new NextRequest('http://localhost/login?redirectTo=/projects/p1'));
     expect(res?.headers.get('location')).toBe('http://localhost/projects/p1');
+    expect(res?.headers.get('x-frame-options')).toBe('DENY');
+    expect(res?.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
+  });
+
+  it('applies clickjacking headers on auth pages', async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null } });
+
+    const forgotPasswordRes = await middleware(new NextRequest('http://localhost/forgot-password'));
+    expect(forgotPasswordRes?.headers.get('x-frame-options')).toBe('DENY');
+    expect(forgotPasswordRes?.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
+
+    const checkEmailRes = await middleware(new NextRequest('http://localhost/check-email'));
+    expect(checkEmailRes?.headers.get('x-frame-options')).toBe('DENY');
+    expect(checkEmailRes?.headers.get('content-security-policy')).toBe("frame-ancestors 'none'");
   });
 
   it('returns 500 when Supabase env is incomplete', async () => {


### PR DESCRIPTION
### Motivation
- The login page had frame protection added previously but the protection needed to be extended to all auth-related public routes to prevent iframe-based clickjacking across the auth surface.
- The change centralizes header injection so anti-framing headers are applied consistently regardless of response type for matching auth routes.

### Description
- Added `shouldApplyClickjackingProtection` and `withClickjackingHeaders` helpers to `middleware.ts` to centralize the anti-framing logic and decisioning for protected paths.
- The middleware now sets `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` for matching routes (`/login`, `/check-email`, `/forgot-password`, `/reset-password`, and `/auth/*`).
- Headers are applied across response types (normal `NextResponse.next()`, redirect responses, maintenance responses, and the incomplete-env 500 response) by wrapping returned responses with `withClickjackingHeaders` when the request `pathname` matches.
- Updated `tests/server/middleware.test.ts` to assert the new anti-framing headers on the authenticated `/login` redirect and on other auth pages like `/forgot-password` and `/check-email`.

### Testing
- Ran the targeted test file with `npm test -- tests/server/middleware.test.ts` using `vitest`, and all tests passed (4 tests, 1 file).
- The updated tests specifically verify the `x-frame-options` and `content-security-policy` headers on protected auth pages and on the login redirect, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cd214a4d4832b89c3ed8eaf11b6e3)