### PR TITLE
Follow-up: clarify model capabilities naming and allowlist docs

### DIFF
--- a/env.example
+++ b/env.example
@@ -55,15 +55,15 @@ OPENAI_MODEL=gpt-5.2
 # Default is true when unset.
 OPENAI_USE_RESPONSES=true
 GEMINI_API_KEY=gemini-
-GEMINI_MODEL=gemini-3-pro-preview
+GEMINI_MODEL=gemini-3.1-pro-preview
 ANTHROPIC_API_KEY=claude-
 ANTHROPIC_MODEL=claude-4-5-sonnet-latest
 ANTHROPIC_BETA=
 
-# Allowed models (comma-separated). If unset/empty, any model is allowed.
-LLM_ALLOWED_MODELS_OPENAI=
-LLM_ALLOWED_MODELS_GEMINI=
-LLM_ALLOWED_MODELS_ANTHROPIC=
+# Deployment allowlist (comma-separated). If unset/empty, all code-defined provider capabilities are allowed.
+LLM_ALLOWED_MODELS_OPENAI=  # Subset of models defined in src/shared/llmCapabilities.ts
+LLM_ALLOWED_MODELS_GEMINI=  # Subset of models defined in src/shared/llmCapabilities.ts
+LLM_ALLOWED_MODELS_ANTHROPIC=  # Subset of models defined in src/shared/llmCapabilities.ts
 
 # Store (provenance)
 # - `git`: provenance stored in on-disk git repos

--- a/src/server/llmConfig.ts
+++ b/src/server/llmConfig.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { LLMProvider } from '@/src/shared/llmProvider';
-import { LLM_ENDPOINTS } from '@/src/shared/llmCapabilities';
+import { LLM_PROVIDER_CAPABILITIES } from '@/src/shared/llmCapabilities';
 
 export interface ProviderEnvConfig {
   enabled: boolean;
@@ -11,6 +11,12 @@ export interface ProviderEnvConfig {
 }
 
 export type DeployEnv = 'dev' | 'prod';
+
+const PROVIDER_CAPABILITIES_PATH = 'src/shared/llmCapabilities.ts';
+
+function buildAllowlistSubsetError(envVarName: string, supportedModels: string[]): string {
+  return `${envVarName} must be a subset of code-defined provider capabilities in ${PROVIDER_CAPABILITIES_PATH} (${supportedModels.join(', ')})`;
+}
 
 export function getDeployEnv(): DeployEnv {
   const raw = (process.env.DEPLOY_ENV ?? 'dev').trim().toLowerCase();
@@ -85,58 +91,58 @@ export function getDefaultProvider(): LLMProvider {
 export function getProviderEnvConfig(provider: LLMProvider): ProviderEnvConfig {
   if (provider === 'openai' || provider === 'openai_responses') {
     const enabled = parseBooleanEnv(process.env.LLM_ENABLE_OPENAI, true);
-    const supportedModels = LLM_ENDPOINTS[provider].models;
+    const supportedModels = LLM_PROVIDER_CAPABILITIES[provider].models;
     const allowedFromEnv = parseCsvEnv(process.env.LLM_ALLOWED_MODELS_OPENAI);
     if (allowedFromEnv && allowedFromEnv.some((model) => !supportedModels.includes(model))) {
       throw new Error(
-        `LLM_ALLOWED_MODELS_OPENAI must be a subset of supported models (${supportedModels.join(', ')})`
+        buildAllowlistSubsetError('LLM_ALLOWED_MODELS_OPENAI', supportedModels)
       );
     }
     const allowedModels = allowedFromEnv ?? supportedModels;
-    const fallbackModel = LLM_ENDPOINTS[provider].defaultModel;
+    const fallbackModel = LLM_PROVIDER_CAPABILITIES[provider].defaultModel;
     const envModel = (process.env.OPENAI_MODEL ?? '').trim();
     const defaultModel = envModel || allowedModels?.[0] || fallbackModel;
     if (!isAllowedModel(allowedModels, defaultModel)) {
-      throw new Error(`OPENAI_MODEL must be one of LLM_ALLOWED_MODELS_OPENAI (${allowedModels?.join(', ') ?? ''})`);
+      throw new Error(`OPENAI_MODEL must be one of the allowed OpenAI models (${allowedModels?.join(', ') ?? ''})`);
     }
     return { enabled, allowedModels, defaultModel };
   }
 
   if (provider === 'gemini') {
     const enabled = parseBooleanEnv(process.env.LLM_ENABLE_GEMINI, true);
-    const supportedModels = LLM_ENDPOINTS.gemini.models;
+    const supportedModels = LLM_PROVIDER_CAPABILITIES.gemini.models;
     const allowedFromEnv = parseCsvEnv(process.env.LLM_ALLOWED_MODELS_GEMINI);
     if (allowedFromEnv && allowedFromEnv.some((model) => !supportedModels.includes(model))) {
       throw new Error(
-        `LLM_ALLOWED_MODELS_GEMINI must be a subset of supported models (${supportedModels.join(', ')})`
+        buildAllowlistSubsetError('LLM_ALLOWED_MODELS_GEMINI', supportedModels)
       );
     }
     const allowedModels = allowedFromEnv ?? supportedModels;
-    const fallbackModel = LLM_ENDPOINTS.gemini.defaultModel;
+    const fallbackModel = LLM_PROVIDER_CAPABILITIES.gemini.defaultModel;
     const envModel = (process.env.GEMINI_MODEL ?? '').trim();
     const defaultModel = envModel || allowedModels?.[0] || fallbackModel;
     if (!isAllowedModel(allowedModels, defaultModel)) {
-      throw new Error(`GEMINI_MODEL must be one of LLM_ALLOWED_MODELS_GEMINI (${allowedModels?.join(', ') ?? ''})`);
+      throw new Error(`GEMINI_MODEL must be one of the allowed Gemini models (${allowedModels?.join(', ') ?? ''})`);
     }
     return { enabled, allowedModels, defaultModel };
   }
 
   if (provider === 'anthropic') {
     const enabled = parseBooleanEnv(process.env.LLM_ENABLE_ANTHROPIC, false);
-    const supportedModels = LLM_ENDPOINTS.anthropic.models;
+    const supportedModels = LLM_PROVIDER_CAPABILITIES.anthropic.models;
     const allowedFromEnv = parseCsvEnv(process.env.LLM_ALLOWED_MODELS_ANTHROPIC);
     if (allowedFromEnv && allowedFromEnv.some((model) => !supportedModels.includes(model))) {
       throw new Error(
-        `LLM_ALLOWED_MODELS_ANTHROPIC must be a subset of supported models (${supportedModels.join(', ')})`
+        buildAllowlistSubsetError('LLM_ALLOWED_MODELS_ANTHROPIC', supportedModels)
       );
     }
     const allowedModels = allowedFromEnv ?? supportedModels;
-    const fallbackModel = LLM_ENDPOINTS.anthropic.defaultModel;
+    const fallbackModel = LLM_PROVIDER_CAPABILITIES.anthropic.defaultModel;
     const envModel = (process.env.ANTHROPIC_MODEL ?? '').trim();
     const defaultModel = envModel || allowedModels?.[0] || fallbackModel;
     if (!isAllowedModel(allowedModels, defaultModel)) {
       throw new Error(
-        `ANTHROPIC_MODEL must be one of LLM_ALLOWED_MODELS_ANTHROPIC (${allowedModels?.join(', ') ?? ''})`
+        `ANTHROPIC_MODEL must be one of the allowed Anthropic models (${allowedModels?.join(', ') ?? ''})`
       );
     }
     return { enabled, allowedModels, defaultModel };

--- a/src/shared/llmCapabilities.ts
+++ b/src/shared/llmCapabilities.ts
@@ -12,7 +12,7 @@ export interface ProviderEndpointConfig {
   models: string[];
 }
 
-export const LLM_ENDPOINTS: Record<LLMProvider, ProviderEndpointConfig> = {
+export const LLM_PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderEndpointConfig> = {
   openai: {
     defaultModel: 'gpt-5.2',
     models: ['gpt-5.2', 'gpt-5.1', 'gpt-4o-mini-search-preview', 'gpt-4o-search-preview']
@@ -22,8 +22,8 @@ export const LLM_ENDPOINTS: Record<LLMProvider, ProviderEndpointConfig> = {
     models: ['gpt-5.2', 'gpt-5.1']
   },
   gemini: {
-    defaultModel: 'gemini-3-pro-preview',
-    models: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash']
+    defaultModel: 'gemini-3.1-pro-preview',
+    models: ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash']
   },
   anthropic: {
     defaultModel: 'claude-sonnet-4-5',
@@ -35,14 +35,17 @@ export const LLM_ENDPOINTS: Record<LLMProvider, ProviderEndpointConfig> = {
   }
 };
 
+// Backwards-compatible alias; prefer LLM_PROVIDER_CAPABILITIES for new usage.
+export const LLM_ENDPOINTS = LLM_PROVIDER_CAPABILITIES;
+
 export function getDefaultModelForProviderFromCapabilities(provider: LLMProvider): string {
-  return LLM_ENDPOINTS[provider].defaultModel;
+  return LLM_PROVIDER_CAPABILITIES[provider].defaultModel;
 }
 
 export function isSupportedModelForProvider(provider: LLMProvider, modelName: string): boolean {
   const normalized = modelName.trim();
   if (!normalized) return false;
-  return LLM_ENDPOINTS[provider].models.includes(normalized);
+  return LLM_PROVIDER_CAPABILITIES[provider].models.includes(normalized);
 }
 
 export interface ThinkingValidationResult {

--- a/tests/server/llm-config.test.ts
+++ b/tests/server/llm-config.test.ts
@@ -52,4 +52,16 @@ describe('llmConfig', () => {
     process.env.LLM_ALLOWED_MODELS_OPENAI = 'gpt-5.1,gpt-5.2';
     expect(getProviderEnvConfig('openai')).toMatchObject({ defaultModel: 'gpt-5.1' });
   });
+
+
+  it('accepts gemini-3.1-pro-preview when present in Gemini allowlist', () => {
+    process.env.GEMINI_MODEL = 'gemini-3.1-pro-preview';
+    process.env.LLM_ALLOWED_MODELS_GEMINI = 'gemini-3.1-pro-preview,gemini-2.5-pro';
+    expect(getProviderEnvConfig('gemini')).toMatchObject({ defaultModel: 'gemini-3.1-pro-preview' });
+  });
+
+  it('surfaces a capabilities-first error when allowlist contains an unknown model', () => {
+    process.env.LLM_ALLOWED_MODELS_GEMINI = 'gemini-9-foo';
+    expect(() => getProviderEnvConfig('gemini')).toThrow(/src\/shared\/llmCapabilities\.ts/);
+  });
 });


### PR DESCRIPTION
### Motivation

- A deployment failure occurred when `GEMINI_MODEL=gemini-3.1-pro-preview` was set but the app validated env allowlists against a code-defined model list that did not include that model, making the env allowlist appear authoritative when it is only a deployment subset.
- The goal is to make the dual-layer model configuration (code capabilities vs deployment allowlist) explicit, improve error messages, and reduce accidental breakage during model upgrades.

### Description

- Renamed the primary capability registry from `LLM_ENDPOINTS` to `LLM_PROVIDER_CAPABILITIES` and kept `LLM_ENDPOINTS` as a backwards-compatible alias; updated usages to reference the clearer name in `src/shared/llmCapabilities.ts` and `src/server/llmConfig.ts`.
- Added `gemini-3.1-pro-preview` to the Gemini capability list and made it the default while retaining `gemini-3-pro-preview` for compatibility in `src/shared/llmCapabilities.ts`.
- Improved `llmConfig` validation by adding `buildAllowlistSubsetError` that references `src/shared/llmCapabilities.ts`, clarified validation/error wording for provider model env vars, and switched lookups to `LLM_PROVIDER_CAPABILITIES` in `src/server/llmConfig.ts`.
- Updated `env.example` to change the Gemini sample default to `gemini-3.1-pro-preview` and clarify that `LLM_ALLOWED_MODELS_*` are deployment allowlists (subsets of code-defined capabilities), and added regression tests in `tests/server/llm-config.test.ts` to cover the new Gemini model and capability-first error guidance.

### Testing

- Ran `npm test -- tests/server/llm-config.test.ts` which passed: 7 tests passed (file `tests/server/llm-config.test.ts`).
- Ran linter: `npm run -s lint src/server/llmConfig.ts src/shared/llmCapabilities.ts tests/server/llm-config.test.ts` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a214bad474832bacbe4996404909db)