### PR TITLE
Add profile-level default provider preference and apply it to creation flows

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -19,7 +19,8 @@ const updateKeysSchema = z
     // Back-compat (UI used "Key" previously).
     openaiKey: z.string().max(500).optional().nullable(),
     geminiKey: z.string().max(500).optional().nullable(),
-    anthropicKey: z.string().max(500).optional().nullable()
+    anthropicKey: z.string().max(500).optional().nullable(),
+    defaultProvider: z.enum(['openai', 'openai_responses', 'gemini', 'anthropic', 'mock']).optional().nullable()
   })
   .strict();
 
@@ -48,6 +49,7 @@ export async function GET() {
         gemini: { configured: status.hasGemini },
         anthropic: { configured: status.hasAnthropic }
       },
+      defaultProvider: status.defaultProvider,
       systemPrompt: {
         mode: status.systemPromptMode,
         prompt: status.systemPrompt
@@ -68,7 +70,7 @@ export async function PUT(request: Request) {
       throw badRequest('Invalid request body', { issues: parsed.error.flatten() });
     }
 
-    const { rtSetUserLlmKeyV1 } = await import('@/src/store/pg/userLlmKeys');
+    const { rtSetUserDefaultProviderV1, rtSetUserLlmKeyV1 } = await import('@/src/store/pg/userLlmKeys');
     const openaiToken = parsed.data.openaiToken ?? parsed.data.openaiKey;
     const geminiToken = parsed.data.geminiToken ?? parsed.data.geminiKey;
     const anthropicToken = parsed.data.anthropicToken ?? parsed.data.anthropicKey;
@@ -81,6 +83,11 @@ export async function PUT(request: Request) {
     }
     if (parsed.data.anthropicToken !== undefined || parsed.data.anthropicKey !== undefined) {
       await rtSetUserLlmKeyV1({ provider: 'anthropic', secret: normalizeSecret(anthropicToken) });
+    }
+
+
+    if (parsed.data.defaultProvider !== undefined) {
+      await rtSetUserDefaultProviderV1({ provider: parsed.data.defaultProvider });
     }
 
     if (parsed.data.systemPrompt !== undefined || parsed.data.systemPromptMode !== undefined) {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -61,8 +61,14 @@ export async function POST(request: Request) {
       throw badRequest('Invalid request body', { issues: parsed.error.flatten() });
     }
 
-    const requestedProvider = resolveOpenAIProviderSelection(parsed.data.provider ?? null);
-    const defaultProvider = resolveLLMProvider(requestedProvider);
+    let defaultProvider = resolveLLMProvider();
+    if (parsed.data.provider) {
+      defaultProvider = resolveOpenAIProviderSelection(parsed.data.provider);
+    } else if (store.mode === 'pg') {
+      const { rtGetUserDefaultProviderV1 } = await import('@/src/store/pg/userLlmKeys');
+      const preferredProvider = await rtGetUserDefaultProviderV1();
+      defaultProvider = resolveLLMProvider(preferredProvider ?? undefined);
+    }
     const defaultModel = getDefaultModelForProvider(defaultProvider);
     const systemPrompt = await getCurrentEffectiveSystemPrompt(store.mode);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,12 +22,16 @@ export default async function HomePage() {
     id: provider,
     label: labelForProvider(provider)
   }));
-  const defaultProvider = resolveLLMProvider();
+  let defaultProvider = resolveLLMProvider();
 
   if (store.mode === 'pg') {
     const currentUser = await requireUser();
     const { rtListProjectsShadowV1 } = await import('@/src/store/pg/projects');
     const { rtGetProjectMainRefUpdatesShadowV1, rtListRefsShadowV2 } = await import('@/src/store/pg/reads');
+    const { rtGetUserDefaultProviderV1 } = await import('@/src/store/pg/userLlmKeys');
+    const preferredProvider = await rtGetUserDefaultProviderV1();
+    defaultProvider = resolveLLMProvider(preferredProvider ?? undefined);
+
     const rows = await rtListProjectsShadowV1();
     const projectIds = rows.map((row) => row.id);
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -15,7 +15,7 @@ export default async function ProfilePage() {
         <div className="mx-auto max-w-2xl space-y-6">
           <header className="space-y-2">
             <h1 className="text-2xl font-semibold text-slate-900">Profile</h1>
-            <p className="text-sm text-muted">Manage your tokens and account settings.</p>
+            <p className="text-sm text-muted">Manage your tokens, default provider, and account settings.</p>
           </header>
           <ProfilePageClient email={user.email ?? null} />
         </div>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { WorkspaceClient } from '@/src/components/workspace/WorkspaceClient';
 import { APP_NAME } from '@/src/config/app';
-import { resolveOpenAIProviderSelection, getDefaultModelForProvider, type LLMProvider } from '@/src/server/llm';
+import { resolveLLMProvider, getDefaultModelForProvider, type LLMProvider } from '@/src/server/llm';
 import { getStoreConfig } from '@/src/server/storeConfig';
 import { requireUser } from '@/src/server/auth';
 import { getEnabledProviders } from '@/src/server/llmConfig';
@@ -138,7 +138,13 @@ export default async function ProjectWorkspace({ params }: ProjectPageProps) {
     label: labelForProvider(id),
     defaultModel: getDefaultModelForProvider(id)
   }));
-  const defaultProvider = resolveOpenAIProviderSelection();
+  let defaultProvider = resolveLLMProvider();
+
+  if (storeMode === 'pg') {
+    const { rtGetUserDefaultProviderV1 } = await import('@/src/store/pg/userLlmKeys');
+    const preferredProvider = await rtGetUserDefaultProviderV1();
+    defaultProvider = resolveLLMProvider(preferredProvider ?? undefined);
+  }
 
   return (
     <main className="min-h-screen bg-white">

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -4,6 +4,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import type { LLMProvider } from '@/src/shared/llmProvider';
 
 type ProfileResponse = {
   user: { id: string; email: string | null };
@@ -12,6 +13,7 @@ type ProfileResponse = {
     gemini: { configured: boolean };
     anthropic: { configured: boolean };
   };
+  defaultProvider: LLMProvider | null;
   systemPrompt: { mode: 'append' | 'replace'; prompt: string | null };
   updatedAt: string | null;
 };
@@ -44,6 +46,8 @@ export function ProfilePageClient({ email }: { email: string | null }) {
   const [clearAnthropic, setClearAnthropic] = useState(false);
   const [systemPromptMode, setSystemPromptMode] = useState<'append' | 'replace'>('append');
   const [systemPromptText, setSystemPromptText] = useState('');
+  const [defaultProvider, setDefaultProvider] = useState<LLMProvider | ''>('');
+  const [savingProvider, setSavingProvider] = useState(false);
   const showTokenLoading = loading && !profile;
 
   const placeholders = useMemo(() => {
@@ -61,6 +65,7 @@ export function ProfilePageClient({ email }: { email: string | null }) {
     setProfile(body);
     setSystemPromptMode(body.systemPrompt?.mode ?? 'append');
     setSystemPromptText(body.systemPrompt?.prompt ?? '');
+    setDefaultProvider(body.defaultProvider ?? '');
   };
 
   useEffect(() => {
@@ -162,6 +167,33 @@ export function ProfilePageClient({ email }: { email: string | null }) {
       setError((err as Error)?.message ?? 'Failed to save system prompt');
     } finally {
       setSavingSystemPrompt(false);
+    }
+  };
+
+  const saveDefaultProvider = async () => {
+    setSavingProvider(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch('/api/profile', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultProvider: defaultProvider || null })
+      });
+      if (!res.ok) {
+        const msg = await res.text().catch(() => '');
+        throw new Error(msg || 'Failed to save default provider');
+      }
+      setNotice('Default provider saved.');
+      try {
+        await loadProfile();
+      } catch {
+        setNotice('Default provider saved. Refresh to load the latest profile state.');
+      }
+    } catch (err) {
+      setError((err as Error)?.message ?? 'Failed to save default provider');
+    } finally {
+      setSavingProvider(false);
     }
   };
 
@@ -279,6 +311,39 @@ export function ProfilePageClient({ email }: { email: string | null }) {
               className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save tokens'}
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-3 border-t border-divider/70 pt-5">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted">Default Provider</div>
+          <p className="text-xs text-muted">Used for new workspaces and new branches when a provider is not explicitly selected.</p>
+          <label className="grid gap-2">
+            <span className="text-sm font-semibold text-slate-900">Provider</span>
+            <select
+              value={defaultProvider}
+              onChange={(e) => setDefaultProvider(e.target.value as LLMProvider | '')}
+              disabled={loading || savingProvider}
+              className="focus-ring h-11 w-full rounded-xl border border-divider/70 bg-white px-4 text-sm text-slate-900 shadow-sm disabled:opacity-60"
+            >
+              <option value="">App default</option>
+              <option value="openai">OpenAI Chat</option>
+              <option value="openai_responses">OpenAI</option>
+              <option value="gemini">Gemini</option>
+              <option value="anthropic">Anthropic</option>
+              <option value="mock">Mock</option>
+            </select>
+          </label>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              disabled={loading || savingProvider}
+              onClick={() => {
+                void saveDefaultProvider();
+              }}
+              className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:opacity-60"
+            >
+              {savingProvider ? 'Saving…' : 'Save default provider'}
             </button>
           </div>
         </div>

--- a/src/store/pg/localAdapter.ts
+++ b/src/store/pg/localAdapter.ts
@@ -130,6 +130,8 @@ const RPC_CONFIG: Record<string, { params: string[]; returnType: RpcReturnType }
   },
   rt_toggle_star_v1: { params: ['p_project_id', 'p_node_id'], returnType: 'scalar' },
   rt_get_user_llm_key_status_v1: { params: [], returnType: 'set' },
+  rt_get_user_default_provider_v1: { params: [], returnType: 'set' },
+  rt_set_user_default_provider_v1: { params: ['p_provider'], returnType: 'void' },
   rt_set_user_llm_key_v1: { params: ['p_provider', 'p_secret'], returnType: 'void' },
   rt_get_user_llm_key_server_v1: { params: ['p_user_id', 'p_provider'], returnType: 'scalar' },
   rt_get_user_system_prompt_v1: { params: [], returnType: 'set' },

--- a/src/store/pg/userLlmKeys.ts
+++ b/src/store/pg/userLlmKeys.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Benjamin F. Hall
 // SPDX-License-Identifier: MIT
 
-import type { LLMProvider } from '@/src/server/llm';
+import { resolveLLMProvider, type LLMProvider } from '@/src/server/llm';
 import type { UserSystemPromptMode } from '@/src/server/systemPrompt';
 import { getPgStoreAdapter } from '@/src/store/pg/adapter';
 
@@ -37,6 +37,7 @@ export async function rtGetUserLlmKeyStatusV1(): Promise<{
   hasOpenAI: boolean;
   hasGemini: boolean;
   hasAnthropic: boolean;
+  defaultProvider: LLMProvider | null;
   systemPrompt: string | null;
   systemPromptMode: UserSystemPromptMode;
   updatedAt: string | null;
@@ -53,6 +54,7 @@ export async function rtGetUserLlmKeyStatusV1(): Promise<{
       hasOpenAI: false,
       hasGemini: false,
       hasAnthropic: false,
+      defaultProvider: null,
       systemPrompt: null,
       systemPromptMode: 'append',
       updatedAt: null
@@ -63,10 +65,34 @@ export async function rtGetUserLlmKeyStatusV1(): Promise<{
     hasOpenAI: Boolean((row as any).has_openai),
     hasGemini: Boolean((row as any).has_gemini),
     hasAnthropic: Boolean((row as any).has_anthropic),
+    defaultProvider: (row as any).default_provider ? resolveLLMProvider(String((row as any).default_provider) as LLMProvider) : null,
     systemPrompt: (row as any).system_prompt ? String((row as any).system_prompt) : null,
     systemPromptMode: (row as any).system_prompt_mode === 'replace' ? 'replace' : 'append',
     updatedAt: (row as any).updated_at ? String((row as any).updated_at) : null
   };
+}
+
+export async function rtGetUserDefaultProviderV1(): Promise<LLMProvider | null> {
+  const { rpc } = getPgStoreAdapter();
+  const { data, error } = await rpc('rt_get_user_default_provider_v1');
+  if (error) {
+    throw new Error(formatRpcError(error));
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  const value = (row as any)?.provider;
+  if (!value) return null;
+  return resolveLLMProvider(String(value) as LLMProvider);
+}
+
+export async function rtSetUserDefaultProviderV1(input: { provider: LLMProvider | null }): Promise<void> {
+  const { rpc } = getPgStoreAdapter();
+  const { error } = await rpc('rt_set_user_default_provider_v1', {
+    p_provider: input.provider
+  });
+  if (error) {
+    throw new Error(formatRpcError(error));
+  }
 }
 
 export async function rtSetUserLlmKeyV1(input: { provider: KeyedProvider; secret: string | null }): Promise<void> {

--- a/supabase/migrations/20260306173300_user_default_provider_profile_setting.sql
+++ b/supabase/migrations/20260306173300_user_default_provider_profile_setting.sql
@@ -1,0 +1,110 @@
+-- Add profile-level default provider preference.
+
+alter table public.user_llm_keys
+  add column if not exists default_provider text;
+
+alter table public.user_llm_keys
+  drop constraint if exists user_llm_keys_default_provider_check;
+
+alter table public.user_llm_keys
+  add constraint user_llm_keys_default_provider_check
+  check (default_provider is null or default_provider in ('openai', 'openai_responses', 'gemini', 'anthropic', 'mock'));
+
+drop function if exists public.rt_get_user_llm_key_status_v1();
+
+create or replace function public.rt_get_user_llm_key_status_v1()
+returns table(
+  has_openai boolean,
+  has_gemini boolean,
+  has_anthropic boolean,
+  default_provider text,
+  system_prompt text,
+  system_prompt_mode text,
+  updated_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+
+  insert into public.user_llm_keys (user_id)
+  values (auth.uid())
+  on conflict do nothing;
+
+  return query
+  select
+    (k.openai_secret_id is not null) as has_openai,
+    (k.gemini_secret_id is not null) as has_gemini,
+    (k.anthropic_secret_id is not null) as has_anthropic,
+    nullif(btrim(coalesce(k.default_provider, '')), '') as default_provider,
+    nullif(btrim(coalesce(k.system_prompt, '')), '') as system_prompt,
+    coalesce(nullif(btrim(k.system_prompt_mode), ''), 'append') as system_prompt_mode,
+    k.updated_at
+  from public.user_llm_keys k
+  where k.user_id = auth.uid();
+end;
+$$;
+
+revoke all on function public.rt_get_user_llm_key_status_v1() from public;
+grant execute on function public.rt_get_user_llm_key_status_v1() to authenticated;
+
+create or replace function public.rt_get_user_default_provider_v1()
+returns table(provider text)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+
+  insert into public.user_llm_keys (user_id)
+  values (auth.uid())
+  on conflict do nothing;
+
+  return query
+  select nullif(btrim(coalesce(k.default_provider, '')), '') as provider
+  from public.user_llm_keys k
+  where k.user_id = auth.uid();
+end;
+$$;
+
+revoke all on function public.rt_get_user_default_provider_v1() from public;
+grant execute on function public.rt_get_user_default_provider_v1() to authenticated;
+
+create or replace function public.rt_set_user_default_provider_v1(p_provider text default null)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_provider text;
+begin
+  if auth.uid() is null then
+    raise exception 'Sign in required';
+  end if;
+
+  v_provider := nullif(btrim(coalesce(p_provider, '')), '');
+  if v_provider is not null and v_provider not in ('openai', 'openai_responses', 'gemini', 'anthropic', 'mock') then
+    raise exception 'Invalid provider';
+  end if;
+
+  insert into public.user_llm_keys (user_id)
+  values (auth.uid())
+  on conflict do nothing;
+
+  update public.user_llm_keys
+  set default_provider = v_provider,
+      updated_at = now()
+  where user_id = auth.uid();
+end;
+$$;
+
+revoke all on function public.rt_set_user_default_provider_v1(text) from public;
+grant execute on function public.rt_set_user_default_provider_v1(text) to authenticated;


### PR DESCRIPTION
### Motivation
- Provide users a profile-level `defaultProvider` preference so new workspaces and branches default to a chosen provider when none is explicitly selected.
- Persist the preference in the PG-backed store and expose it via the profile API so server-side flows can honor the user setting.
- Surface a simple UI in Profile so users can choose and save their preferred provider alongside tokens and system prompts.

### Description
- Add `defaultProvider` handling to the profile API by accepting it in `PUT /api/profile` and returning it from `GET /api/profile` in `app/api/profile/route.ts` and persisting via new store APIs.
- Extend PG store helpers with `rtGetUserDefaultProviderV1`, `rtSetUserDefaultProviderV1`, and include `defaultProvider` in `rtGetUserLlmKeyStatusV1`, plus register local adapter RPCs in `src/store/pg/localAdapter.ts` and helpers in `src/store/pg/userLlmKeys.ts`.
- Apply the preference as a fallback in creation/default resolution paths in `app/api/projects/route.ts`, the home page (`app/page.tsx`), and the workspace page (`app/projects/[id]/page.tsx`) so new projects/branches use the user preference when no provider is supplied.
- Add a Profile UI section in `src/components/profile/ProfilePageClient.tsx` with a provider `<select>` and save behavior, update copy in `app/profile/page.tsx`, and add a Supabase migration `supabase/migrations/20260306173300_user_default_provider_profile_setting.sql` to persist and constrain `user_llm_keys.default_provider` and expose RPCs.

### Testing
- `npm run lint` completed successfully (typecheck and custom checks passed). ✅
- `npm run dev` started the app locally and served pages successfully for manual validation. ✅
- Captured a Playwright screenshot of `/profile` to validate the UI rendering via the dev server. ✅
- A network search step (`curl -I 'https://duckduckgo.com/html/?q=nextjs+server+component+user+profile+default+settings'`) returned `403` due to an environment proxy and could not be used; this did not block implementation or local validation. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0f9f88b8832b8ae5e5125cf707f0)