### PR TITLE
[Follow-up][BUG] Add bounded crossing metric gating to layout fallback selection

### DIFF
--- a/src/components/workspace/WorkspaceGraph.tsx
+++ b/src/components/workspace/WorkspaceGraph.tsx
@@ -978,6 +978,7 @@ interface LayoutResult {
 
 interface LayoutOptions {
   maxIterations?: number;
+  crossingComparisonBudget?: number;
 }
 
 type LabelAlignmentMode = 'hug' | 'left-aligned';
@@ -993,6 +994,74 @@ interface EdgeLaneSpan {
   fromLane: number;
   toLane: number;
   maxLane?: number;
+}
+
+export interface EdgeSegment {
+  startRow: number;
+  endRow: number;
+  startLane: number;
+  endLane: number;
+}
+
+export type CrossingMetricResult =
+  | {
+      status: 'ok';
+      crossings: number;
+      comparisons: number;
+    }
+  | {
+      status: 'unavailable';
+      comparisons: number;
+      budget: number;
+    };
+
+function toEdgeSegments(edgeLaneSpans: EdgeLaneSpan[]): EdgeSegment[] {
+  return edgeLaneSpans.map((span) => {
+    const startRow = Math.min(span.fromRow, span.toRow);
+    const endRow = Math.max(span.fromRow, span.toRow);
+    const startLane = span.fromRow <= span.toRow ? span.fromLane : span.toLane;
+    const endLane = span.fromRow <= span.toRow ? span.toLane : span.fromLane;
+    return { startRow, endRow, startLane, endLane };
+  });
+}
+
+function interpolateLane(segment: EdgeSegment, row: number): number {
+  if (segment.endRow === segment.startRow) return segment.startLane;
+  const ratio = (row - segment.startRow) / (segment.endRow - segment.startRow);
+  return segment.startLane + (segment.endLane - segment.startLane) * ratio;
+}
+
+export function segmentsCrossInSharedSpan(a: EdgeSegment, b: EdgeSegment): boolean {
+  const sharedStart = Math.max(a.startRow, b.startRow);
+  const sharedEnd = Math.min(a.endRow, b.endRow);
+
+  // Endpoint-only contact is not a crossing.
+  if (sharedEnd <= sharedStart) return false;
+
+  const laneDiffAtStart = interpolateLane(a, sharedStart) - interpolateLane(b, sharedStart);
+  const laneDiffAtEnd = interpolateLane(a, sharedEnd) - interpolateLane(b, sharedEnd);
+
+  // Ordering must strictly flip across the shared span.
+  return laneDiffAtStart * laneDiffAtEnd < 0;
+}
+
+export function countCrossingsBounded(edgeSegments: EdgeSegment[], budget: number): CrossingMetricResult {
+  let crossings = 0;
+  let comparisons = 0;
+
+  for (let i = 0; i < edgeSegments.length; i += 1) {
+    for (let j = i + 1; j < edgeSegments.length; j += 1) {
+      if (comparisons >= budget) {
+        return { status: 'unavailable', comparisons, budget };
+      }
+      comparisons += 1;
+      if (segmentsCrossInSharedSpan(edgeSegments[i], edgeSegments[j])) {
+        crossings += 1;
+      }
+    }
+  }
+
+  return { status: 'ok', crossings, comparisons };
 }
 
 export function computeRowLabelPlacement(lanesByRow: number[], edgeLaneSpans: EdgeLaneSpan[]): RowLabelPlacement {
@@ -1263,7 +1332,45 @@ export function layoutGraph(
     });
   });
 
-  return { nodes: flowNodes, edges: flowEdges, usedFallback: false };
+  const gitLayout: LayoutResult = { nodes: flowNodes, edges: flowEdges, usedFallback: false };
+
+  const crossingComparisonBudget = options?.crossingComparisonBudget ?? graphNodes.length * 32 + 256;
+  const gitCrossings = countCrossingsBounded(toEdgeSegments(edgeLaneSpans), crossingComparisonBudget);
+
+  const simpleIdToIndex = new Map(graphNodesOldestFirst.map((node, idx) => [node.id, idx]));
+  const simpleLaneByBranch = new Map<string, number>([
+    [trunkName, 0],
+    [branchName, 1]
+  ]);
+  let nextSimpleLane = 2;
+  const simpleLaneFor = (branchId: string) => {
+    if (!simpleLaneByBranch.has(branchId)) {
+      simpleLaneByBranch.set(branchId, nextSimpleLane++);
+    }
+    return simpleLaneByBranch.get(branchId)!;
+  };
+  const simpleLanes = graphNodesOldestFirst.map((node) => simpleLaneFor(node.laneBranchId));
+  const simpleSpans: EdgeLaneSpan[] = [];
+  graphNodesOldestFirst.forEach((node, rowIndex) => {
+    node.parents.forEach((parentId) => {
+      const parentIndex = simpleIdToIndex.get(parentId);
+      if (typeof parentIndex !== 'number') return;
+      simpleSpans.push({
+        fromRow: parentIndex,
+        toRow: rowIndex,
+        fromLane: simpleLanes[parentIndex],
+        toLane: simpleLanes[rowIndex]
+      });
+    });
+  });
+
+  const simpleCrossings = countCrossingsBounded(toEdgeSegments(simpleSpans), crossingComparisonBudget);
+
+  if (gitCrossings.status === 'ok' && simpleCrossings.status === 'ok' && simpleCrossings.crossings < gitCrossings.crossings) {
+    return simple;
+  }
+
+  return gitLayout;
 }
 
 

--- a/tests/client/WorkspaceGraph.layout.test.ts
+++ b/tests/client/WorkspaceGraph.layout.test.ts
@@ -4,9 +4,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   buildGraphNodes,
+  countCrossingsBounded,
   computeLabelTranslateX,
   computeRowLabelPlacement,
   layoutGraph,
+  segmentsCrossInSharedSpan,
+  type EdgeSegment,
   type GraphNode
 } from '@/src/components/workspace/WorkspaceGraph';
 
@@ -163,6 +166,70 @@ describe('label placement helpers', () => {
     expect(hug).toBe(14);
     expect(leftAligned).toBe(50);
     expect(leftAligned).toBeGreaterThan(hug);
+  });
+});
+
+describe('crossing metrics', () => {
+  it('counts crossings when lane ordering flips over shared row coverage', () => {
+    const a: EdgeSegment = { startRow: 0, endRow: 4, startLane: 0, endLane: 4 };
+    const b: EdgeSegment = { startRow: 0, endRow: 4, startLane: 4, endLane: 0 };
+
+    expect(segmentsCrossInSharedSpan(a, b)).toBe(true);
+    expect(countCrossingsBounded([a, b], 10)).toEqual({ status: 'ok', crossings: 1, comparisons: 1 });
+  });
+
+  it('does not count parallel segments as crossings', () => {
+    const a: EdgeSegment = { startRow: 0, endRow: 4, startLane: 0, endLane: 1 };
+    const b: EdgeSegment = { startRow: 0, endRow: 4, startLane: 2, endLane: 3 };
+
+    expect(segmentsCrossInSharedSpan(a, b)).toBe(false);
+  });
+
+  it('does not count endpoint-only touches as crossings', () => {
+    const a: EdgeSegment = { startRow: 0, endRow: 2, startLane: 0, endLane: 2 };
+    const b: EdgeSegment = { startRow: 2, endRow: 4, startLane: 2, endLane: 0 };
+
+    expect(segmentsCrossInSharedSpan(a, b)).toBe(false);
+  });
+
+  it('does not count segments with disjoint row spans as crossings', () => {
+    const a: EdgeSegment = { startRow: 0, endRow: 1, startLane: 0, endLane: 3 };
+    const b: EdgeSegment = { startRow: 3, endRow: 5, startLane: 3, endLane: 0 };
+
+    expect(segmentsCrossInSharedSpan(a, b)).toBe(false);
+  });
+
+  it('uses shared-span interpolation before deciding if ordering flips', () => {
+    const long: EdgeSegment = { startRow: 0, endRow: 6, startLane: 0, endLane: 6 };
+    const partial: EdgeSegment = { startRow: 2, endRow: 5, startLane: 5, endLane: 2 };
+
+    expect(segmentsCrossInSharedSpan(long, partial)).toBe(true);
+  });
+
+  it('returns metric unavailable when comparison budget is exhausted', () => {
+    const segments: EdgeSegment[] = [
+      { startRow: 0, endRow: 4, startLane: 0, endLane: 4 },
+      { startRow: 0, endRow: 4, startLane: 4, endLane: 0 },
+      { startRow: 0, endRow: 4, startLane: 1, endLane: 1 }
+    ];
+
+    expect(countCrossingsBounded(segments, 2)).toEqual({ status: 'unavailable', comparisons: 2, budget: 2 });
+  });
+});
+
+describe('crossing-aware layout selection', () => {
+  it('switches to fallback only when bounded metrics show strict crossing improvement', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a', parents: [], laneBranchId: 'main', originBranchId: 'main', isOnActiveBranch: true, label: 'A' },
+      { id: 'b', parents: ['a'], laneBranchId: 'main', originBranchId: 'main', isOnActiveBranch: true, label: 'B' },
+      { id: 'c', parents: ['a'], laneBranchId: 'feature', originBranchId: 'feature', isOnActiveBranch: false, label: 'C' },
+      { id: 'd', parents: ['b', 'c'], laneBranchId: 'main', originBranchId: 'main', isOnActiveBranch: true, label: 'D' }
+    ];
+
+    const result = layoutGraph(nodes, 'feature', 'main', undefined, { maxIterations: 200, crossingComparisonBudget: 0 });
+
+    // Budget exhaustion means metric is unavailable; selection remains on non-fallback layout.
+    expect(result.usedFallback).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Crossing quality must be measured independently from label alignment using a geometry-aware, bounded metric to avoid false positives from endpoint touches and disjoint spans. 
- The layout chooser should only switch to a fallback layout when a bounded, reliable crossing metric demonstrates a strict improvement. 

### Description
- Add `EdgeSegment` primitives and `toEdgeSegments`/`interpolateLane` helpers to represent and sample edge geometry in layout row-space. 
- Implement `segmentsCrossInSharedSpan` to detect crossings only when two segments share row coverage and their lane ordering strictly flips across that shared span, excluding endpoint-only contacts and disjoint spans. 
- Implement a bounded pairwise counter `countCrossingsBounded` that returns `{ status: 'unavailable' }` when the comparison budget is exceeded and expose a `crossingComparisonBudget` layout option. 
- Wire the bounded metric into `layoutGraph` so it computes bounded crossing counts for both the GitGraph layout and the simple fallback and only switches to the fallback when both metrics are `ok` and the fallback has strictly fewer crossings, and export helpers for future reuse. 
- Add unit tests exercising positive crossings, non-crossings, endpoint-only touches, disjoint spans, shared-span interpolation, budget exhaustion, and crossing-aware layout selection. 

### Testing
- Ran the focused Vitest file `tests/client/WorkspaceGraph.layout.test.ts` which includes the added crossing metric and layout selection tests, and all tests passed (`17 tests, 1 file`). 
- The new tests validate `segmentsCrossInSharedSpan`, `countCrossingsBounded`, and crossing-aware selection behavior under budget exhaustion (metric unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8806fd778832b8e25b99408998ea1)