### PR TITLE
fix: keep the workspace composer above the branch legend

### DIFF
--- a/src/components/workspace/WorkspaceComposer.tsx
+++ b/src/components/workspace/WorkspaceComposer.tsx
@@ -363,7 +363,7 @@ export const WorkspaceComposer = forwardRef<WorkspaceComposerHandle, WorkspaceCo
         event.preventDefault();
         void handleSubmit();
       }}
-      className="pointer-events-none fixed inset-x-0 bottom-0 pb-[calc(env(safe-area-inset-bottom)+1rem)]"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-20 pb-[calc(env(safe-area-inset-bottom)+1rem)]"
     >
       <div
         className="pointer-events-auto mx-auto max-w-6xl px-4 md:pr-12"


### PR DESCRIPTION
### Motivation
- The branch-legend control inside the graph panel could visually overlap the composer when the composer expands upward, so the composer needs a higher stacking context to remain usable.

### Description
- Add `z-20` to the fixed `CommandEnterForm` wrapper in `src/components/workspace/WorkspaceComposer.tsx` so the workspace composer is rendered above the branch legend while leaving the legend's placement inside the graph panel unchanged.

### Testing
- Ran `npm run lint` which passed, and ran `npm run test -- tests/client/WorkspaceClient.test.tsx` which surfaced unrelated long-running test timeouts (4 failing tests); none of the failures referenced this one-line z-index change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a1d39388832b954156679ff841c6)