### PR TITLE
[Follow-up][BUG] Make workspace hotkeys fire even when composer textarea has focus

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -3007,17 +3007,8 @@ export function WorkspaceClient({
         setInsightTab('canvas');
         return;
       }
-      if (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'b') {
-        const target = event.target as HTMLElement | null;
-        if (
-          target &&
-          (target.tagName === 'INPUT' ||
-            target.tagName === 'TEXTAREA' ||
-            target.tagName === 'SELECT' ||
-            target.isContentEditable)
-        ) {
-          return;
-        }
+      const hasToggleModifier = event.metaKey || event.ctrlKey;
+      if (hasToggleModifier && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'b') {
         event.preventDefault();
         if (insightCollapsed) {
           expandInsights();
@@ -3037,19 +3028,10 @@ export function WorkspaceClient({
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (!event.metaKey || !event.shiftKey || event.ctrlKey || event.altKey) return;
+      const hasToggleModifier = event.metaKey || event.ctrlKey;
+      if (!hasToggleModifier || !event.shiftKey || event.altKey) return;
       if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
       event.preventDefault();
       toggleAllWorkspacePanels();
     };
@@ -3060,19 +3042,10 @@ export function WorkspaceClient({
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (!event.metaKey || event.shiftKey || event.ctrlKey || event.altKey) return;
+      const hasToggleModifier = event.metaKey || event.ctrlKey;
+      if (!hasToggleModifier || event.shiftKey || event.altKey) return;
       if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
       event.preventDefault();
       toggleComposerCollapsed();
     };


### PR DESCRIPTION
### Motivation

- Ensure workspace-level hotkeys continue to work even when the composer textarea has focus so typing in the composer no longer swallows supported shortcuts.
- Provide parity across platforms by accepting either `Meta` or `Ctrl` as the modifier for the same shortcuts.

### Description

- Updated `src/components/workspace/WorkspaceClient.tsx` to remove input/textarea/contenteditable target guards for the workspace toggle shortcuts so they no longer bail out when the composer is focused.
- Normalized modifier handling to accept `event.metaKey || event.ctrlKey` for parity and clarity.
- Applied the change to three handlers: `Meta/Ctrl + B` (rail toggle), `Meta/Ctrl + Shift + K` (toggle all panels), and `Meta/Ctrl + K` (toggle composer collapsed state). 
- Left single-character composer typing behavior (which intentionally ignores global handling when typing in other inputs) unchanged except where required for the above shortcuts.

### Testing

- Ran `npm run typecheck` (which runs `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c458d79dd4832baaf391dba67e7d29)