### PR TITLE
Add hotkey scope guards and mark interactive regions to prevent accidental hotkeys

### DIFF
--- a/src/components/layout/RailLayout.tsx
+++ b/src/components/layout/RailLayout.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { APP_NAME, storageKey } from '@/src/config/app';
 import { MenuIcon } from '@/src/components/workspace/HeroIcons';
+import { resolveHotkeyScope, shouldBlockHotkey } from '@/src/components/workspace/hotkeyGuards';
 
 const COLLAPSE_KEY = storageKey('rail-collapsed');
 
@@ -54,9 +55,8 @@ export function RailLayout({
       if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
       const key = event.key.toLowerCase();
       if (key !== 'b') return;
-      const target = event.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      if (tag === 'input' || tag === 'textarea' || target?.isContentEditable) return;
+      const scope = resolveHotkeyScope(event.target);
+      if (shouldBlockHotkey('toggle_left_rail', scope)) return;
       event.preventDefault();
       toggleRail();
     };

--- a/src/components/workspace/NewBranchFormCard.tsx
+++ b/src/components/workspace/NewBranchFormCard.tsx
@@ -19,6 +19,7 @@ export function NewBranchFormCard({
   autoFocus = false,
   variant = 'card',
   containerClassName,
+  hotkeyScope,
   testId,
   inputTestId,
   submitTestId
@@ -35,6 +36,7 @@ export function NewBranchFormCard({
   autoFocus?: boolean;
   variant?: 'card' | 'plain';
   containerClassName?: string;
+  hotkeyScope?: string;
   testId?: string;
   inputTestId?: string;
   submitTestId?: string;
@@ -55,6 +57,7 @@ export function NewBranchFormCard({
         containerClassName ?? '',
       ].join(' ')}
       data-testid={testId}
+      data-hotkey-scope={hotkeyScope}
     >
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold text-slate-900">New branch</span>

--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -53,6 +53,7 @@ import { copyTextToClipboard } from './clipboard';
 import type { GraphViews } from '@/src/shared/graph';
 import { buildGraphPayload } from '@/src/shared/graph/buildGraph';
 import { deriveForkParentNodeId } from '@/src/shared/graph/deriveForkParentNodeId';
+import { resolveHotkeyScope, shouldBlockHotkey } from '@/src/components/workspace/hotkeyGuards';
 
 const fetchJson = async <T,>(url: string): Promise<T> => {
   const res = await fetch(url);
@@ -2991,33 +2992,19 @@ export function WorkspaceClient({
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const onKeyDown = (event: KeyboardEvent) => {
+      const scope = resolveHotkeyScope(event.target);
       if (event.key === 'ArrowLeft') {
-        const target = event.target as HTMLElement | null;
-        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
-          return;
-        }
+        if (shouldBlockHotkey('insight_nav_left', scope)) return;
         setInsightTab('graph');
         return;
       }
       if (event.key === 'ArrowRight') {
-        const target = event.target as HTMLElement | null;
-        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
-          return;
-        }
+        if (shouldBlockHotkey('insight_nav_right', scope)) return;
         setInsightTab('canvas');
         return;
       }
       if (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'b') {
-        const target = event.target as HTMLElement | null;
-        if (
-          target &&
-          (target.tagName === 'INPUT' ||
-            target.tagName === 'TEXTAREA' ||
-            target.tagName === 'SELECT' ||
-            target.isContentEditable)
-        ) {
-          return;
-        }
+        if (shouldBlockHotkey('toggle_insights', scope)) return;
         event.preventDefault();
         if (insightCollapsed) {
           expandInsights();
@@ -3040,16 +3027,7 @@ export function WorkspaceClient({
       if (!event.metaKey || !event.shiftKey || event.ctrlKey || event.altKey) return;
       if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
+      if (shouldBlockHotkey('toggle_all_panels', resolveHotkeyScope(event.target))) return;
       event.preventDefault();
       toggleAllWorkspacePanels();
     };
@@ -3063,16 +3041,7 @@ export function WorkspaceClient({
       if (!event.metaKey || event.shiftKey || event.ctrlKey || event.altKey) return;
       if (event.key.toLowerCase() !== 'k') return;
       if (state.isStreaming) return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
+      if (shouldBlockHotkey('toggle_composer', resolveHotkeyScope(event.target))) return;
       event.preventDefault();
       toggleComposerCollapsed();
     };
@@ -3086,16 +3055,7 @@ export function WorkspaceClient({
       if (state.isStreaming) return;
       if (event.metaKey || event.ctrlKey || event.altKey || event.isComposing) return;
       if (event.key.length !== 1 || event.key === ' ') return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return;
-      }
+      if (shouldBlockHotkey('type_to_open_composer', resolveHotkeyScope(event.target))) return;
       event.preventDefault();
       if (composerCollapsed) {
         expandComposer();
@@ -5122,6 +5082,7 @@ export function WorkspaceClient({
                     disabled={isSwitching || isRenaming || branchActionDisabled}
                     submitting={isCreating}
                     error={branchActionError}
+                    hotkeyScope="branch-actions"
                     testId="branch-form-rail"
                     inputTestId="branch-form-rail-input"
                     submitTestId="branch-form-rail-submit"
@@ -6013,6 +5974,7 @@ export function WorkspaceClient({
                               ) : (
                                 <div className="relative h-full">
                                   <textarea
+                                    data-hotkey-scope="canvas"
                                     value={artefactDraft}
                                     onChange={(event) => setArtefactDraft(event.target.value)}
                                     onFocus={() => setIsCanvasFocused(true)}
@@ -6134,6 +6096,7 @@ export function WorkspaceClient({
             ref={newBranchModalRef}
             className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl"
             data-testid="branch-modal"
+            data-hotkey-scope="branch-actions"
           >
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 text-lg font-semibold text-slate-900">
@@ -6252,6 +6215,7 @@ export function WorkspaceClient({
                 disabled={isSwitching || branchActionDisabled}
                 submitting={isCreating}
                 error={branchActionError}
+                hotkeyScope="branch-actions"
                 testId="branch-form-modal"
                 inputTestId="branch-form-modal-input"
                 submitTestId="branch-form-modal-submit"
@@ -6365,7 +6329,7 @@ export function WorkspaceClient({
           onMouseDown={handleMergeBackdrop}
           onTouchStart={handleMergeBackdrop}
         >
-          <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl" data-testid="merge-modal">
+          <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl" data-testid="merge-modal" data-hotkey-scope="branch-actions">
             <h3 className="text-lg font-semibold text-slate-900">
               Merge {displayBranchName(branchName)} into {displayBranchName(mergeTargetBranch)}
             </h3>
@@ -6618,7 +6582,7 @@ export function WorkspaceClient({
           onMouseDown={handleRenameBackdrop}
           onTouchStart={handleRenameBackdrop}
         >
-          <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl" data-testid="rename-modal">
+          <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl" data-testid="rename-modal" data-hotkey-scope="branch-actions">
             <h3 className="text-lg font-semibold text-slate-900">Rename branch</h3>
             <p className="text-sm text-muted">This only changes the label. History, drafts, and Canvas stay intact.</p>
             <div className="mt-4 space-y-2">
@@ -6671,7 +6635,7 @@ export function WorkspaceClient({
           onMouseDown={handleEditBackdrop}
           onTouchStart={handleEditBackdrop}
         >
-          <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl" data-testid="edit-modal">
+          <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl" data-testid="edit-modal" data-hotkey-scope="branch-actions">
             <CommandEnterForm
               onSubmit={(event) => {
                 event.preventDefault();
@@ -6794,7 +6758,7 @@ export function WorkspaceClient({
           onMouseDown={handleShareBackdrop}
           onTouchStart={handleShareBackdrop}
         >
-          <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-2xl" data-testid="share-modal">
+          <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-2xl" data-testid="share-modal" data-hotkey-scope="branch-actions">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <h3 className="text-lg font-semibold text-slate-900">Share workspace</h3>

--- a/src/components/workspace/WorkspaceComposer.tsx
+++ b/src/components/workspace/WorkspaceComposer.tsx
@@ -435,6 +435,7 @@ export const WorkspaceComposer = forwardRef<WorkspaceComposerHandle, WorkspaceCo
           <div className="relative flex flex-1 items-center">
             <textarea
               ref={composerTextareaRef}
+              data-hotkey-scope="composer"
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
               placeholder="Ask anything"

--- a/src/components/workspace/hotkeyGuards.ts
+++ b/src/components/workspace/hotkeyGuards.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+export type HotkeyIntent =
+  | 'toggle_left_rail'
+  | 'toggle_insights'
+  | 'toggle_composer'
+  | 'toggle_all_panels'
+  | 'insight_nav_left'
+  | 'insight_nav_right'
+  | 'type_to_open_composer';
+
+export type HotkeyScope =
+  | 'none'
+  | 'composer'
+  | 'canvas'
+  | 'branch-actions'
+  | 'input'
+  | 'textarea'
+  | 'select'
+  | 'contenteditable';
+
+const EDITABLE_SCOPES: ReadonlySet<HotkeyScope> = new Set(['composer', 'canvas', 'branch-actions', 'input', 'textarea', 'select', 'contenteditable']);
+
+function parseScope(value: string | null): HotkeyScope | null {
+  if (!value) return null;
+  if (
+    value === 'none' ||
+    value === 'composer' ||
+    value === 'canvas' ||
+    value === 'branch-actions' ||
+    value === 'input' ||
+    value === 'textarea' ||
+    value === 'select' ||
+    value === 'contenteditable'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+export function resolveHotkeyScope(target: EventTarget | null): HotkeyScope {
+  if (!(target instanceof HTMLElement)) return 'none';
+
+  const scopedAncestor = target.closest<HTMLElement>('[data-hotkey-scope]');
+  const scopedValue = parseScope(scopedAncestor?.getAttribute('data-hotkey-scope') ?? null);
+  if (scopedValue) {
+    return scopedValue;
+  }
+
+  const tag = target.tagName.toLowerCase();
+  if (tag === 'input') return 'input';
+  if (tag === 'textarea') return 'textarea';
+  if (tag === 'select') return 'select';
+  if (target.isContentEditable) return 'contenteditable';
+
+  return 'none';
+}
+
+export function isEditableHotkeyScope(scope: HotkeyScope): boolean {
+  return EDITABLE_SCOPES.has(scope);
+}
+
+export function shouldBlockHotkey(intent: HotkeyIntent, scope: HotkeyScope): boolean {
+  if (intent === 'insight_nav_left' || intent === 'insight_nav_right' || intent === 'type_to_open_composer') {
+    return isEditableHotkeyScope(scope);
+  }
+
+  if (intent === 'toggle_left_rail' || intent === 'toggle_insights' || intent === 'toggle_all_panels' || intent === 'toggle_composer') {
+    if (scope === 'composer') return false;
+    if (scope === 'branch-actions') return true;
+    if (isEditableHotkeyScope(scope)) return true;
+    return false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
### Motivation

- Prevent global keyboard shortcuts from triggering while the user is focused on inputs, textareas, composer, canvas, or modal/branch UI by centralizing hotkey blocking logic.

### Description

- Add a new `src/components/workspace/hotkeyGuards.ts` module that exports `resolveHotkeyScope`, `shouldBlockHotkey`, and related types to determine whether a hotkey should be blocked based on DOM context and `data-hotkey-scope` attributes.  
- Replace ad-hoc tag/isContentEditable checks with `resolveHotkeyScope` and `shouldBlockHotkey` in `RailLayout.tsx`, `WorkspaceClient.tsx`, and other places to gate hotkey handling.  
- Annotate interactive elements and modals with `data-hotkey-scope` (for example `branch-actions`, `canvas`, `composer`) and expose a `hotkeyScope` prop on `NewBranchFormCard` to allow scoped hotkey behavior.  
- Update composer and canvas textareas and various modal containers to include the `data-hotkey-scope` attributes and import the new guard utilities where needed.

### Testing

- Ran TypeScript type check with `tsc --noEmit` and it completed successfully.  
- Ran the project test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46485d13c832ba46556b16196c5b6)