### PR TITLE
Add chat export to clipboard for branch chat history (with payload caps and tests)

### DIFF
--- a/src/components/workspace/WorkspaceClient.tsx
+++ b/src/components/workspace/WorkspaceClient.tsx
@@ -50,6 +50,7 @@ import {
 } from './HeroIcons';
 import { MarkdownWithCopy } from './MarkdownWithCopy';
 import { copyTextToClipboard } from './clipboard';
+import { buildChatExportPayload, EXPORT_CHAT_MAX_BYTES, EXPORT_CHAT_MAX_MESSAGES } from './chatExport';
 import type { GraphViews } from '@/src/shared/graph';
 import { buildGraphPayload } from '@/src/shared/graph/buildGraph';
 import { deriveForkParentNodeId } from '@/src/shared/graph/deriveForkParentNodeId';
@@ -393,7 +394,7 @@ type BackgroundTask = {
   switchOnComplete: boolean;
 };
 
-type ToastTone = 'info' | 'success' | 'error';
+type ToastTone = 'info' | 'success' | 'error' | 'warning';
 
 type ToastMessage = {
   id: string;
@@ -1303,6 +1304,8 @@ export function WorkspaceClient({
   const [isCanvasFocused, setIsCanvasFocused] = useState(false);
   const [graphCopyFeedback, setGraphCopyFeedback] = useState(false);
   const graphCopyFeedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [exportChatCopyFeedback, setExportChatCopyFeedback] = useState(false);
+  const exportChatCopyFeedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [insightCollapsed, setInsightCollapsed] = useState(false);
   const [chatPaneWidth, setChatPaneWidth] = useState<number | null>(null);
   const [insightPaneWidth, setInsightPaneWidth] = useState<number | null>(null);
@@ -2569,6 +2572,35 @@ export function WorkspaceClient({
   const branchActionDisabled =
     state.isStreaming || assistantLifecycle === 'pending' || assistantLifecycle === 'streaming';
   const isSending = state.isStreaming || assistantLifecycle === 'pending' || assistantLifecycle === 'streaming';
+  const handleExportChat = useCallback(async () => {
+    const result = buildChatExportPayload(nodes);
+    if (!result.ok) {
+      if (result.reason === 'record_cap') {
+        pushToast('warning', `Chat export is limited to ${EXPORT_CHAT_MAX_MESSAGES} messages.`);
+        return;
+      }
+      if (result.reason === 'payload_cap') {
+        pushToast('warning', `Chat export is limited to ${Math.floor(EXPORT_CHAT_MAX_BYTES / 1024)} KiB.`);
+        return;
+      }
+      pushToast('warning', 'No chat messages are available to export.');
+      return;
+    }
+
+    const didCopy = await copyTextToClipboard(result.payload);
+    if (!didCopy) {
+      pushToast('warning', 'Chat history copy failed. Please try again.');
+      return;
+    }
+    setExportChatCopyFeedback(true);
+    if (exportChatCopyFeedbackTimeoutRef.current) {
+      clearTimeout(exportChatCopyFeedbackTimeoutRef.current);
+    }
+    exportChatCopyFeedbackTimeoutRef.current = setTimeout(() => {
+      setExportChatCopyFeedback(false);
+      exportChatCopyFeedbackTimeoutRef.current = null;
+    }, 1200);
+  }, [nodes, pushToast]);
 
   const toggleComposerCollapsed = useCallback(
     (next?: boolean) => {
@@ -2840,6 +2872,9 @@ export function WorkspaceClient({
     if (tone === 'error') {
       return 'border-red-200 bg-red-50 text-red-700';
     }
+    if (tone === 'warning') {
+      return 'border-amber-200 bg-amber-50 text-amber-800';
+    }
     return 'border-slate-200 bg-white text-slate-800';
   };
   const pendingBranchNames = useMemo(
@@ -3073,6 +3108,10 @@ export function WorkspaceClient({
       if (graphCopyFeedbackTimeoutRef.current) {
         clearTimeout(graphCopyFeedbackTimeoutRef.current);
         graphCopyFeedbackTimeoutRef.current = null;
+      }
+      if (exportChatCopyFeedbackTimeoutRef.current) {
+        clearTimeout(exportChatCopyFeedbackTimeoutRef.current);
+        exportChatCopyFeedbackTimeoutRef.current = null;
       }
       if (jumpHighlightTimeoutRef.current) {
         clearTimeout(jumpHighlightTimeoutRef.current);
@@ -5582,6 +5621,28 @@ export function WorkspaceClient({
                                     <BlueprintIcon icon="unlock" className="h-4 w-4" />
                                   </button>
                                 ) : null}
+                                <div className="group relative">
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      void handleExportChat();
+                                    }}
+                                    disabled={branchActionDisabled || isSwitching || isCreating}
+                                    aria-label="Export chat history"
+                                    aria-describedby="branch-settings-export-chat-tooltip"
+                                    title={branchActionDisabled ? 'Export is disabled while streaming' : undefined}
+                                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-divider/70 bg-white text-slate-700 transition hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50"
+                                  >
+                                    <BlueprintIcon icon={exportChatCopyFeedback ? 'tick' : 'document-share'} className="h-4 w-4" />
+                                  </button>
+                                  <span
+                                    id="branch-settings-export-chat-tooltip"
+                                    role="tooltip"
+                                    className="pointer-events-none absolute right-full top-1/2 mr-2 -translate-y-1/2 whitespace-nowrap rounded-md border border-divider/80 bg-slate-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                                  >
+                                    Copy full chat history of current branch to clipboard
+                                  </span>
+                                </div>
                                 <button
                                   type="button"
                                   onClick={() => {

--- a/src/components/workspace/chatExport.ts
+++ b/src/components/workspace/chatExport.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+import type { NodeRecord } from '@git/types';
+import type { ThinkingContentBlock } from '@/src/shared/thinkingTraces';
+import { getContentBlocksWithLegacyFallback } from '@/src/shared/thinkingTraces';
+
+export const EXPORT_CHAT_MAX_MESSAGES = 500;
+export const EXPORT_CHAT_MAX_BYTES = 1024 * 1024;
+
+export interface ExportChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string | ThinkingContentBlock[];
+}
+
+export type ExportChatPayloadResult =
+  | {
+      ok: true;
+      payload: string;
+      messages: ExportChatMessage[];
+      bytes: number;
+    }
+  | {
+      ok: false;
+      reason: 'no_messages' | 'record_cap' | 'payload_cap';
+      messageCount: number;
+      bytes?: number;
+    };
+
+function toExportChatMessage(node: NodeRecord): ExportChatMessage | null {
+  if (node.type !== 'message') return null;
+  if (node.role !== 'system' && node.role !== 'user' && node.role !== 'assistant') return null;
+  const blocks = getContentBlocksWithLegacyFallback(node);
+  const content = blocks.length > 0 ? blocks : node.content ?? '';
+  return {
+    role: node.role,
+    content
+  };
+}
+
+export function buildChatExportPayload(nodes: NodeRecord[]): ExportChatPayloadResult {
+  const messages = nodes.map(toExportChatMessage).filter((entry): entry is ExportChatMessage => Boolean(entry));
+
+  if (messages.length === 0) {
+    return { ok: false, reason: 'no_messages', messageCount: 0 };
+  }
+
+  if (messages.length > EXPORT_CHAT_MAX_MESSAGES) {
+    return { ok: false, reason: 'record_cap', messageCount: messages.length };
+  }
+
+  const payload = JSON.stringify(messages, null, 2);
+  const bytes = new TextEncoder().encode(payload).length;
+  if (bytes > EXPORT_CHAT_MAX_BYTES) {
+    return { ok: false, reason: 'payload_cap', messageCount: messages.length, bytes };
+  }
+
+  return {
+    ok: true,
+    payload,
+    messages,
+    bytes
+  };
+}

--- a/src/components/workspace/clipboard.ts
+++ b/src/components/workspace/clipboard.ts
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 Benjamin F. Hall
 // SPDX-License-Identifier: MIT
 
-export const copyTextToClipboard = async (text: string) => {
-  if (typeof navigator === 'undefined') return;
+export const copyTextToClipboard = async (text: string): Promise<boolean> => {
+  if (typeof navigator === 'undefined') return false;
   try {
     await navigator.clipboard.writeText(text);
-    return;
+    return true;
   } catch {
     // ignore and fall back
   }
@@ -19,7 +19,9 @@ export const copyTextToClipboard = async (text: string) => {
     textarea.select();
     document.execCommand('copy');
     document.body.removeChild(textarea);
+    return true;
   } catch {
     // ignore
   }
+  return false;
 };

--- a/src/components/workspace/clipboard.ts
+++ b/src/components/workspace/clipboard.ts
@@ -17,9 +17,9 @@ export const copyTextToClipboard = async (text: string): Promise<boolean> => {
     textarea.style.left = '-9999px';
     document.body.appendChild(textarea);
     textarea.select();
-    document.execCommand('copy');
+    const copied = document.execCommand('copy');
     document.body.removeChild(textarea);
-    return true;
+    return copied;
   } catch {
     // ignore
   }

--- a/tests/client/chatExport.test.ts
+++ b/tests/client/chatExport.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { NodeRecord } from '@git/types';
+import { buildChatExportPayload, EXPORT_CHAT_MAX_MESSAGES } from '@/src/components/workspace/chatExport';
+
+const baseMessage = (overrides: Partial<NodeRecord> = {}): NodeRecord => ({
+  id: 'm-1',
+  type: 'message',
+  role: 'user',
+  content: 'hello',
+  timestamp: Date.now(),
+  parent: null,
+  ...overrides
+} as NodeRecord);
+
+describe('buildChatExportPayload', () => {
+  it('exports message nodes only and strips rawResponse from output', () => {
+    const nodes: NodeRecord[] = [
+      baseMessage({ id: 'm-user', role: 'user', content: 'Question' }),
+      {
+        id: 's-1',
+        type: 'state',
+        artefactSnapshot: 'draft',
+        timestamp: Date.now(),
+        parent: null
+      },
+      {
+        id: 'merge-1',
+        type: 'merge',
+        mergeFrom: 'feature/x',
+        mergeSummary: 'summary',
+        sourceCommit: 'abc123',
+        sourceNodeIds: [],
+        timestamp: Date.now(),
+        parent: null
+      },
+      baseMessage({ id: 'm-assistant', role: 'assistant', content: 'Answer', rawResponse: { hidden: true } as any })
+    ];
+
+    const result = buildChatExportPayload(nodes);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Question' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Answer' }] }
+    ]);
+    expect(result.payload).not.toContain('rawResponse');
+  });
+
+  it('includes thinking blocks in content when available', () => {
+    const nodes: NodeRecord[] = [
+      baseMessage({
+        role: 'assistant',
+        content: 'final answer',
+        thinking: {
+          provider: 'openai',
+          availability: 'summary',
+          content: [{ type: 'thinking', thinking: 'chain' }]
+        }
+      })
+    ];
+
+    const result = buildChatExportPayload(nodes);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(Array.isArray(result.messages[0]?.content)).toBe(true);
+    expect(result.messages[0]).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'chain' },
+        { type: 'text', text: 'final answer' }
+      ]
+    });
+  });
+
+  it('fails when message count exceeds cap', () => {
+    const nodes = Array.from({ length: EXPORT_CHAT_MAX_MESSAGES + 1 }, (_, idx) =>
+      baseMessage({ id: `m-${idx}`, content: `msg-${idx}` })
+    );
+
+    const result = buildChatExportPayload(nodes);
+    expect(result).toEqual({
+      ok: false,
+      reason: 'record_cap',
+      messageCount: EXPORT_CHAT_MAX_MESSAGES + 1
+    });
+  });
+
+  it('fails when serialized payload exceeds size cap', () => {
+    const oversized = 'a'.repeat(1024 * 1024 + 512);
+    const nodes: NodeRecord[] = [baseMessage({ content: oversized })];
+
+    const result = buildChatExportPayload(nodes);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('payload_cap');
+    expect(result.bytes).toBeGreaterThan(1024 * 1024);
+  });
+});

--- a/tests/client/clipboard.test.ts
+++ b/tests/client/clipboard.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyTextToClipboard } from '@/src/components/workspace/clipboard';
+
+describe('copyTextToClipboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when navigator clipboard API succeeds', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    });
+
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('returns false when fallback execCommand reports failure', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error('denied'))
+      }
+    });
+    const execSpy = vi.fn().mockReturnValue(false);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execSpy
+    });
+
+    await expect(copyTextToClipboard('hello')).resolves.toBe(false);
+    expect(execSpy).toHaveBeenCalledWith('copy');
+  });
+
+  it('returns true when fallback execCommand succeeds', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error('denied'))
+      }
+    });
+    const execSpy = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execSpy
+    });
+
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true);
+    expect(execSpy).toHaveBeenCalledWith('copy');
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a way to export the full chat history of the current branch to the clipboard while enforcing message and payload size limits.

### Description

- Add a new `chatExport.ts` utility with `buildChatExportPayload`, `EXPORT_CHAT_MAX_MESSAGES`, and `EXPORT_CHAT_MAX_BYTES` to build and validate an exportable JSON payload of message nodes.
- Add a boolean-returning `copyTextToClipboard` in `clipboard.ts` and wire a new `handleExportChat` handler in `WorkspaceClient` to build the payload, copy it to clipboard, and show toast/feedback for capacity and copy failures using a new `exportChatCopyFeedback` state.
- Add a new export button and tooltip to the branch settings UI that triggers `handleExportChat`, and add a `warning` toast tone style for capacity/copy warnings.
- Add cleanup for the export copy feedback timeout and import the new helpers into `WorkspaceClient`.

### Testing

- Add `tests/client/chatExport.test.ts` with unit tests that validate exporting only message nodes, inclusion of thinking blocks, record count cap handling, and payload size cap handling using `buildChatExportPayload`.
- Run unit tests with `vitest` and the new `chatExport` tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c702d21934832ba54d8e2d34c757a5)