### PR TITLE
feat: sheets editor - text wrap settings

### DIFF
--- a/src/components/sheets/SheetEditor.tsx
+++ b/src/components/sheets/SheetEditor.tsx
@@ -130,6 +130,11 @@ export function SheetEditor({ initialCells, onCellsChange }: SheetEditorProps) {
               const selected = isCellInSelection(selection, rowIndex, colIndex);
               const canOverflowRight = canOverflowIntoRightCell(cells, rowIndex, colIndex);
               const isClippedOverflow = wrapMode === DEFAULT_TEXT_WRAP_MODE && !canOverflowRight;
+              const cellTextOverflowClass = canOverflowRight
+                ? 'relative z-20 min-w-max bg-white/95 pr-2'
+                : wrapMode === 'wrap'
+                  ? ''
+                  : 'truncate';
               return (
                 <button
                   key={`${rowIndex}-${colIndex}`}
@@ -155,7 +160,7 @@ export function SheetEditor({ initialCells, onCellsChange }: SheetEditorProps) {
                       wrapMode === 'wrap'
                         ? 'whitespace-normal break-words leading-snug'
                         : 'whitespace-nowrap leading-snug'
-                    } ${canOverflowRight ? 'relative z-20 min-w-max bg-white/95 pr-2' : 'truncate'}`}
+                    } ${cellTextOverflowClass}`}
                     title={cell.value}
                   >
                     {cell.value}

--- a/src/components/sheets/SheetEditor.tsx
+++ b/src/components/sheets/SheetEditor.tsx
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { BlueprintIcon } from '@/src/components/ui/BlueprintIcon';
+import {
+  applyTextWrapModeToSelection,
+  canOverflowIntoRightCell,
+  createSheetCells,
+  DEFAULT_TEXT_WRAP_MODE,
+  getCellWrapMode,
+  getSelectedWrapMode,
+  isCellInSelection,
+  normalizeSelection,
+  TEXT_WRAP_MODE_DESCRIPTIONS,
+  TEXT_WRAP_MODE_LABELS,
+  TEXT_WRAP_MODES,
+  type CellSelection,
+  type SheetCell,
+  type TextWrapMode
+} from './textWrap';
+
+const WRAP_MODE_ICONS: Record<TextWrapMode, string> = {
+  overflow: 'lengthen-text',
+  wrap: 'wrap-lines',
+  clip: 'clip'
+};
+
+const DEFAULT_SHEET_VALUES = [
+  ['Long project note that should overflow into empty cells when possible', '', 'Status'],
+  ['Wrapped notes stay readable inside a single cell', 'Owner', 'Due date'],
+  ['Clipped notes keep the sheet compact without changing row height', '', '']
+];
+
+type SheetEditorProps = {
+  initialCells?: SheetCell[][];
+  onCellsChange?: (cells: SheetCell[][]) => void;
+};
+
+const cloneCells = (cells: SheetCell[][]): SheetCell[][] => cells.map((row) => row.map((cell) => ({ ...cell })));
+
+const columnName = (index: number) => String.fromCharCode(65 + index);
+
+const selectedRangeLabel = (selection: CellSelection) => {
+  const normalized = normalizeSelection(selection);
+  const start = `${columnName(normalized.startCol)}${normalized.startRow + 1}`;
+  const end = `${columnName(normalized.endCol)}${normalized.endRow + 1}`;
+  return start === end ? start : `${start}:${end}`;
+};
+
+export function SheetEditor({ initialCells, onCellsChange }: SheetEditorProps) {
+  const [cells, setCells] = useState<SheetCell[][]>(() =>
+    initialCells ? cloneCells(initialCells) : createSheetCells(DEFAULT_SHEET_VALUES)
+  );
+  const [selection, setSelection] = useState<CellSelection>({ startRow: 0, startCol: 0, endRow: 0, endCol: 0 });
+  const [wrapMenuOpen, setWrapMenuOpen] = useState(false);
+  const selectedWrapMode = useMemo(() => getSelectedWrapMode(cells, selection), [cells, selection]);
+  const columnCount = Math.max(...cells.map((row) => row.length));
+
+  const commitCells = (nextCells: SheetCell[][]) => {
+    setCells(nextCells);
+    onCellsChange?.(nextCells);
+  };
+
+  const applyWrapMode = (wrapMode: TextWrapMode) => {
+    commitCells(applyTextWrapModeToSelection(cells, selection, wrapMode));
+    setWrapMenuOpen(false);
+  };
+
+  return (
+    <section className="rounded-2xl border border-divider/80 bg-white shadow-sm" aria-label="Sheet editor">
+      <div className="flex flex-wrap items-center gap-2 border-b border-divider/80 bg-slate-50/80 px-3 py-2">
+        <div className="rounded-lg border border-divider/70 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700">
+          {selectedRangeLabel(selection)}
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-divider/70 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm hover:bg-primary/10"
+            aria-haspopup="menu"
+            aria-expanded={wrapMenuOpen}
+            aria-label="Text wrapping"
+            onClick={() => setWrapMenuOpen((open) => !open)}
+          >
+            <BlueprintIcon
+              icon={selectedWrapMode === 'mixed' ? 'wrap-lines' : WRAP_MODE_ICONS[selectedWrapMode]}
+              className="h-4 w-4 text-slate-600"
+            />
+            <span>{selectedWrapMode === 'mixed' ? 'Mixed wrap' : TEXT_WRAP_MODE_LABELS[selectedWrapMode]}</span>
+            <BlueprintIcon icon="caret-down" className="h-3.5 w-3.5 text-slate-500" />
+          </button>
+          {wrapMenuOpen ? (
+            <div
+              role="menu"
+              aria-label="Text wrapping options"
+              className="absolute left-0 top-full z-30 mt-2 w-56 overflow-hidden rounded-xl border border-divider/80 bg-white py-1 shadow-lg"
+            >
+              {TEXT_WRAP_MODES.map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selectedWrapMode === mode}
+                  className="flex w-full items-start gap-2 px-3 py-2 text-left text-xs text-slate-700 hover:bg-primary/10"
+                  onClick={() => applyWrapMode(mode)}
+                >
+                  <BlueprintIcon icon={WRAP_MODE_ICONS[mode]} className="mt-0.5 h-4 w-4 text-slate-600" />
+                  <span>
+                    <span className="block font-semibold">{TEXT_WRAP_MODE_LABELS[mode]}</span>
+                    <span className="block text-[11px] leading-snug text-slate-500">
+                      {TEXT_WRAP_MODE_DESCRIPTIONS[mode]}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="overflow-auto p-3">
+        <div
+          className="grid min-w-max border-l border-t border-slate-200 text-sm"
+          style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(9rem, 9rem))` }}
+        >
+          {cells.map((row, rowIndex) =>
+            row.map((cell, colIndex) => {
+              const wrapMode = getCellWrapMode(cell);
+              const selected = isCellInSelection(selection, rowIndex, colIndex);
+              const canOverflowRight = canOverflowIntoRightCell(cells, rowIndex, colIndex);
+              const isClippedOverflow = wrapMode === DEFAULT_TEXT_WRAP_MODE && !canOverflowRight;
+              return (
+                <button
+                  key={`${rowIndex}-${colIndex}`}
+                  type="button"
+                  className={`relative min-h-10 border-b border-r border-slate-200 bg-white px-2 py-1 text-left align-top focus:z-20 focus:outline-none focus:ring-2 focus:ring-primary/40 ${
+                    selected ? 'z-10 bg-primary/10 ring-1 ring-primary/50' : ''
+                  } ${canOverflowRight ? 'overflow-visible' : 'overflow-hidden'}`}
+                  data-testid={`sheet-cell-${rowIndex}-${colIndex}`}
+                  data-wrap-mode={wrapMode}
+                  data-overflow-blocked={isClippedOverflow ? 'true' : 'false'}
+                  aria-label={`${columnName(colIndex)}${rowIndex + 1}`}
+                  onClick={(event) => {
+                    setSelection((current) => ({
+                      startRow: event.shiftKey ? current.startRow : rowIndex,
+                      startCol: event.shiftKey ? current.startCol : colIndex,
+                      endRow: rowIndex,
+                      endCol: colIndex
+                    }));
+                  }}
+                >
+                  <span
+                    className={`block ${
+                      wrapMode === 'wrap'
+                        ? 'whitespace-normal break-words leading-snug'
+                        : 'whitespace-nowrap leading-snug'
+                    } ${canOverflowRight ? 'relative z-20 min-w-max bg-white/95 pr-2' : 'truncate'}`}
+                    title={cell.value}
+                  >
+                    {cell.value}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sheets/textWrap.ts
+++ b/src/components/sheets/textWrap.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+export const TEXT_WRAP_MODES = ['overflow', 'wrap', 'clip'] as const;
+
+export type TextWrapMode = (typeof TEXT_WRAP_MODES)[number];
+
+export type SheetCell = {
+  value: string;
+  wrapMode?: TextWrapMode;
+};
+
+export type CellSelection = {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+};
+
+export const DEFAULT_TEXT_WRAP_MODE: TextWrapMode = 'overflow';
+
+export const TEXT_WRAP_MODE_LABELS: Record<TextWrapMode, string> = {
+  overflow: 'Overflow',
+  wrap: 'Wrap',
+  clip: 'Clip'
+};
+
+export const TEXT_WRAP_MODE_DESCRIPTIONS: Record<TextWrapMode, string> = {
+  overflow: 'Let text continue into empty cells to the right.',
+  wrap: 'Wrap text onto multiple lines inside the cell.',
+  clip: 'Hide text that does not fit inside the cell.'
+};
+
+export const getCellWrapMode = (cell: SheetCell | undefined): TextWrapMode =>
+  cell?.wrapMode ?? DEFAULT_TEXT_WRAP_MODE;
+
+export const normalizeSelection = (selection: CellSelection): CellSelection => ({
+  startRow: Math.min(selection.startRow, selection.endRow),
+  startCol: Math.min(selection.startCol, selection.endCol),
+  endRow: Math.max(selection.startRow, selection.endRow),
+  endCol: Math.max(selection.startCol, selection.endCol)
+});
+
+export const isCellInSelection = (selection: CellSelection, rowIndex: number, colIndex: number): boolean => {
+  const normalized = normalizeSelection(selection);
+  return (
+    rowIndex >= normalized.startRow &&
+    rowIndex <= normalized.endRow &&
+    colIndex >= normalized.startCol &&
+    colIndex <= normalized.endCol
+  );
+};
+
+export const getSelectedWrapMode = (cells: SheetCell[][], selection: CellSelection): TextWrapMode | 'mixed' => {
+  const normalized = normalizeSelection(selection);
+  let firstMode: TextWrapMode | null = null;
+  for (let rowIndex = normalized.startRow; rowIndex <= normalized.endRow; rowIndex += 1) {
+    for (let colIndex = normalized.startCol; colIndex <= normalized.endCol; colIndex += 1) {
+      const mode = getCellWrapMode(cells[rowIndex]?.[colIndex]);
+      if (!firstMode) {
+        firstMode = mode;
+      } else if (firstMode !== mode) {
+        return 'mixed';
+      }
+    }
+  }
+  return firstMode ?? DEFAULT_TEXT_WRAP_MODE;
+};
+
+export const applyTextWrapModeToSelection = (
+  cells: SheetCell[][],
+  selection: CellSelection,
+  wrapMode: TextWrapMode
+): SheetCell[][] => {
+  const normalized = normalizeSelection(selection);
+  return cells.map((row, rowIndex) =>
+    row.map((cell, colIndex) => {
+      if (!isCellInSelection(normalized, rowIndex, colIndex)) {
+        return cell;
+      }
+      return { ...cell, wrapMode };
+    })
+  );
+};
+
+export const hasBlockingCellToRight = (cells: SheetCell[][], rowIndex: number, colIndex: number): boolean => {
+  const nextCell = cells[rowIndex]?.[colIndex + 1];
+  return Boolean(nextCell?.value.trim());
+};
+
+export const canOverflowIntoRightCell = (cells: SheetCell[][], rowIndex: number, colIndex: number): boolean => {
+  const cell = cells[rowIndex]?.[colIndex];
+  return Boolean(
+    cell?.value.trim() &&
+      getCellWrapMode(cell) === 'overflow' &&
+      cells[rowIndex]?.[colIndex + 1] &&
+      !hasBlockingCellToRight(cells, rowIndex, colIndex)
+  );
+};
+
+export const createSheetCells = (values: string[][]): SheetCell[][] =>
+  values.map((row) => row.map((value) => ({ value, wrapMode: DEFAULT_TEXT_WRAP_MODE })));

--- a/tests/client/SheetEditor.test.tsx
+++ b/tests/client/SheetEditor.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SheetEditor } from '@/src/components/sheets/SheetEditor';
+import {
+  applyTextWrapModeToSelection,
+  canOverflowIntoRightCell,
+  createSheetCells,
+  getCellWrapMode
+} from '@/src/components/sheets/textWrap';
+
+describe('sheet text wrapping', () => {
+  it('defaults cells to overflow mode', () => {
+    const cells = createSheetCells([['Long text']]);
+
+    expect(getCellWrapMode(cells[0][0])).toBe('overflow');
+  });
+
+  it('applies a wrap mode to an arbitrary rectangular selection', () => {
+    const cells = createSheetCells([
+      ['A1', 'B1', 'C1'],
+      ['A2', 'B2', 'C2'],
+      ['A3', 'B3', 'C3']
+    ]);
+
+    const nextCells = applyTextWrapModeToSelection(
+      cells,
+      { startRow: 0, startCol: 0, endRow: 2, endCol: 1 },
+      'clip'
+    );
+
+    expect(nextCells[0][0].wrapMode).toBe('clip');
+    expect(nextCells[2][1].wrapMode).toBe('clip');
+    expect(nextCells[0][2].wrapMode).toBe('overflow');
+  });
+
+  it('allows overflow only when the right-adjacent cell is empty', () => {
+    const cells = createSheetCells([
+      ['Long text', '', 'Blocked text', 'Neighbor'],
+    ]);
+
+    expect(canOverflowIntoRightCell(cells, 0, 0)).toBe(true);
+    expect(canOverflowIntoRightCell(cells, 0, 2)).toBe(false);
+  });
+
+  it('opens a toolbar submenu and applies wrap formatting to the selected range', () => {
+    render(
+      <SheetEditor
+        initialCells={createSheetCells([
+          ['A1', 'B1'],
+          ['A2', 'B2']
+        ])}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sheet-cell-0-0'));
+    fireEvent.click(screen.getByTestId('sheet-cell-1-1'), { shiftKey: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Text wrapping' }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Wrap/ }));
+
+    expect(screen.getByTestId('sheet-cell-0-0')).toHaveAttribute('data-wrap-mode', 'wrap');
+    expect(screen.getByTestId('sheet-cell-1-1')).toHaveAttribute('data-wrap-mode', 'wrap');
+  });
+});

--- a/tests/client/SheetEditor.test.tsx
+++ b/tests/client/SheetEditor.test.tsx
@@ -43,6 +43,24 @@ describe('sheet text wrapping', () => {
     expect(canOverflowIntoRightCell(cells, 0, 2)).toBe(false);
   });
 
+  it('does not truncate cells rendered in wrap mode when overflow is blocked', () => {
+    render(
+      <SheetEditor
+        initialCells={createSheetCells([
+          ['Long text that should wrap inside this cell instead of truncating', 'Neighbor']
+        ])}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sheet-cell-0-0'));
+    fireEvent.click(screen.getByRole('button', { name: 'Text wrapping' }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Wrap/ }));
+
+    const wrappedText = screen.getByTestId('sheet-cell-0-0').querySelector('span');
+    expect(wrappedText).toHaveClass('whitespace-normal');
+    expect(wrappedText).not.toHaveClass('truncate');
+  });
+
   it('opens a toolbar submenu and applies wrap formatting to the selected range', () => {
     render(
       <SheetEditor


### PR DESCRIPTION
### Motivation

- Provide spreadsheet-style text wrapping controls for sheet cells with three modes: `overflow`, `wrap`, and `clip`, matching industry UX expectations. 
- Default to `overflow` while ensuring overflow is blocked when the right-adjacent cell contains content.
- Allow applying wrapping formatting to arbitrary rectangular cell selections from a toolbar for efficient editing.

### Description

- Add typed helper module `src/components/sheets/textWrap.ts` implementing wrap modes, selection normalization, selection apply logic, and overflow-block detection.  
- Add a reusable `SheetEditor` component at `src/components/sheets/SheetEditor.tsx` with a Blueprint-icon toolbar submenu to pick `overflow|wrap|clip`, rectangular shift-click selection, selected-range display, and cell rendering that shows/wraps/clips text appropriately.  
- Use Blueprint icons via `src/components/ui/BlueprintIcon.tsx` for toolbar visuals and keep CSS classes consistent with existing UI patterns.  
- Add unit tests `tests/client/SheetEditor.test.tsx` covering defaults, range formatting, overflow blocking, and the toolbar submenu flow.

### Testing

- Ran unit tests with `npm run test -- --run tests/client/SheetEditor.test.tsx` and all tests passed (`4 passed`).
- Ran typecheck/lint via `npm run lint` (which runs `tsc --noEmit` and internal checks) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4d801ff4832bb75b517abcc0a1ee)