### PR TITLE
feat: add sheets header selection editor primitives

### DIFF
--- a/src/components/sheets/SheetsEditor.tsx
+++ b/src/components/sheets/SheetsEditor.tsx
@@ -52,6 +52,7 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
   const columnCount = normalizedData[0]?.length ?? 1;
   const [selection, setSelection] = useState<SheetSelection>(() => createCellSelection(0, 0));
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
+  const editingCellRef = useRef<EditingCell | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -63,18 +64,25 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
     });
   }, [columnCount, rowCount]);
 
-  const commitEdit = (nextValue = editingCell?.value ?? '') => {
-    if (!editingCell) return;
+  const updateEditingCell = (nextEditingCell: EditingCell | null) => {
+    editingCellRef.current = nextEditingCell;
+    setEditingCell(nextEditingCell);
+  };
+
+  const commitEdit = (nextValue = editingCellRef.current?.value ?? '') => {
+    const cellToCommit = editingCellRef.current;
+    if (!cellToCommit) return;
+    editingCellRef.current = null;
     const nextData = normalizedData.map((row) => [...row]);
-    nextData[editingCell.rowIndex][editingCell.columnIndex] = nextValue;
+    nextData[cellToCommit.rowIndex][cellToCommit.columnIndex] = nextValue;
     onChange?.(nextData);
-    setEditingCell(null);
+    updateEditingCell(null);
   };
 
   const focusGrid = () => gridRef.current?.focus();
 
   const handleHeaderSelection = (nextSelection: SheetSelection) => {
-    setEditingCell(null);
+    updateEditingCell(null);
     setSelection(nextSelection);
     focusGrid();
   };
@@ -90,7 +98,7 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
 
     if (!readOnly && isPrintableSheetEntryKey(event.nativeEvent)) {
       event.preventDefault();
-      setEditingCell({ ...selection.active, value: event.key });
+      updateEditingCell({ ...selection.active, value: event.key });
     }
   };
 
@@ -159,7 +167,7 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
                       data-active={isActive || undefined}
                       className={`min-w-28 border-b border-r border-divider/80 p-0 ${isSelected ? 'bg-primary/5' : ''} ${isActive ? 'outline outline-2 -outline-offset-2 outline-primary' : ''}`}
                       onMouseDown={() => {
-                        setEditingCell(null);
+                        updateEditingCell(null);
                         setSelection(createCellSelection(rowIndex, columnIndex));
                       }}
                     >
@@ -169,7 +177,7 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
                           aria-label={`Edit cell ${rowIndex + 1}, ${columnIndex + 1}`}
                           className="h-full w-full bg-white px-3 py-2 outline-none"
                           value={editingCell.value}
-                          onChange={(event) => setEditingCell({ rowIndex, columnIndex, value: event.target.value })}
+                          onChange={(event) => updateEditingCell({ rowIndex, columnIndex, value: event.target.value })}
                           onBlur={() => commitEdit()}
                           onKeyDown={(event) => {
                             if (event.key === 'Enter' || event.key === 'Tab') {
@@ -180,7 +188,7 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
                             }
                             if (event.key === 'Escape') {
                               event.preventDefault();
-                              setEditingCell(null);
+                              updateEditingCell(null);
                               focusGrid();
                             }
                           }}
@@ -190,7 +198,7 @@ export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, 
                           type="button"
                           className="block h-full min-h-9 w-full px-3 py-2 text-left"
                           onDoubleClick={() => {
-                            if (!readOnly) setEditingCell({ rowIndex, columnIndex, value: cell });
+                            if (!readOnly) updateEditingCell({ rowIndex, columnIndex, value: cell });
                           }}
                         >
                           {cell}

--- a/src/components/sheets/SheetsEditor.tsx
+++ b/src/components/sheets/SheetsEditor.tsx
@@ -1,0 +1,209 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createCellSelection,
+  createColumnSelection,
+  createRowSelection,
+  isCellInSelection,
+  isPrintableSheetEntryKey,
+  moveSheetSelectionForward,
+  type SheetCellPosition,
+  type SheetSelection
+} from './sheetSelection';
+
+type SheetsEditorProps = {
+  data: string[][];
+  readOnly?: boolean;
+  rowLabels?: string[];
+  columnLabels?: string[];
+  onChange?: (nextData: string[][]) => void;
+};
+
+type EditingCell = SheetCellPosition & {
+  value: string;
+};
+
+const toColumnLabel = (columnIndex: number): string => {
+  let value = columnIndex + 1;
+  let label = '';
+  while (value > 0) {
+    const modulo = (value - 1) % 26;
+    label = String.fromCharCode(65 + modulo) + label;
+    value = Math.floor((value - modulo) / 26);
+  }
+  return label;
+};
+
+const normalizeData = (data: string[][]): string[][] => {
+  const columnCount = Math.max(1, ...data.map((row) => row.length));
+  const rowCount = Math.max(1, data.length);
+  return Array.from({ length: rowCount }, (_, rowIndex) =>
+    Array.from({ length: columnCount }, (_, columnIndex) => data[rowIndex]?.[columnIndex] ?? '')
+  );
+};
+
+export const SheetsEditor = ({ data, readOnly = false, rowLabels, columnLabels, onChange }: SheetsEditorProps) => {
+  const normalizedData = useMemo(() => normalizeData(data), [data]);
+  const rowCount = normalizedData.length;
+  const columnCount = normalizedData[0]?.length ?? 1;
+  const [selection, setSelection] = useState<SheetSelection>(() => createCellSelection(0, 0));
+  const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSelection((current) => {
+      const rowIndex = Math.min(current.active.rowIndex, rowCount - 1);
+      const columnIndex = Math.min(current.active.columnIndex, columnCount - 1);
+      if (rowIndex === current.active.rowIndex && columnIndex === current.active.columnIndex) return current;
+      return createCellSelection(rowIndex, columnIndex);
+    });
+  }, [columnCount, rowCount]);
+
+  const commitEdit = (nextValue = editingCell?.value ?? '') => {
+    if (!editingCell) return;
+    const nextData = normalizedData.map((row) => [...row]);
+    nextData[editingCell.rowIndex][editingCell.columnIndex] = nextValue;
+    onChange?.(nextData);
+    setEditingCell(null);
+  };
+
+  const focusGrid = () => gridRef.current?.focus();
+
+  const handleHeaderSelection = (nextSelection: SheetSelection) => {
+    setEditingCell(null);
+    setSelection(nextSelection);
+    focusGrid();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (editingCell) return;
+
+    if (event.key === 'Tab' || event.key === 'Enter') {
+      event.preventDefault();
+      setSelection((current) => moveSheetSelectionForward(current, rowCount, columnCount));
+      return;
+    }
+
+    if (!readOnly && isPrintableSheetEntryKey(event.nativeEvent)) {
+      event.preventDefault();
+      setEditingCell({ ...selection.active, value: event.key });
+    }
+  };
+
+  return (
+    <div
+      ref={gridRef}
+      role="grid"
+      tabIndex={0}
+      aria-label="Sheets editor"
+      aria-readonly={readOnly}
+      data-selection-kind={selection.kind}
+      className="max-w-full overflow-auto rounded-xl border border-divider/80 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+      onKeyDownCapture={handleKeyDown}
+    >
+      <table className="min-w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            <th className="sticky left-0 top-0 z-20 border-b border-r border-divider/80 bg-slate-50 px-3 py-2" aria-hidden="true" />
+            {Array.from({ length: columnCount }, (_, columnIndex) => {
+              const isSelected = selection.kind === 'column' && selection.anchor.columnIndex === columnIndex;
+              return (
+                <th key={columnIndex} className="border-b border-r border-divider/80 bg-slate-50 p-0">
+                  <button
+                    type="button"
+                    className={`h-full w-full px-3 py-2 text-xs font-semibold ${isSelected ? 'bg-primary/10 text-primary' : 'text-slate-600 hover:bg-primary/5'}`}
+                    aria-label={`Select column ${columnLabels?.[columnIndex] ?? toColumnLabel(columnIndex)}`}
+                    aria-pressed={isSelected}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleHeaderSelection(createColumnSelection(columnIndex))}
+                  >
+                    {columnLabels?.[columnIndex] ?? toColumnLabel(columnIndex)}
+                  </button>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {normalizedData.map((row, rowIndex) => {
+            const isRowSelected = selection.kind === 'row' && selection.anchor.rowIndex === rowIndex;
+            return (
+              <tr key={rowIndex}>
+                <th className="sticky left-0 z-10 border-b border-r border-divider/80 bg-slate-50 p-0">
+                  <button
+                    type="button"
+                    className={`h-full w-full px-3 py-2 text-xs font-semibold ${isRowSelected ? 'bg-primary/10 text-primary' : 'text-slate-600 hover:bg-primary/5'}`}
+                    aria-label={`Select row ${rowLabels?.[rowIndex] ?? rowIndex + 1}`}
+                    aria-pressed={isRowSelected}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => handleHeaderSelection(createRowSelection(rowIndex))}
+                  >
+                    {rowLabels?.[rowIndex] ?? rowIndex + 1}
+                  </button>
+                </th>
+                {row.map((cell, columnIndex) => {
+                  const isActive =
+                    selection.active.rowIndex === rowIndex && selection.active.columnIndex === columnIndex;
+                  const isSelected = isCellInSelection(selection, rowIndex, columnIndex);
+                  const isEditing =
+                    editingCell?.rowIndex === rowIndex && editingCell.columnIndex === columnIndex;
+                  return (
+                    <td
+                      key={columnIndex}
+                      role="gridcell"
+                      aria-selected={isSelected}
+                      data-active={isActive || undefined}
+                      className={`min-w-28 border-b border-r border-divider/80 p-0 ${isSelected ? 'bg-primary/5' : ''} ${isActive ? 'outline outline-2 -outline-offset-2 outline-primary' : ''}`}
+                      onMouseDown={() => {
+                        setEditingCell(null);
+                        setSelection(createCellSelection(rowIndex, columnIndex));
+                      }}
+                    >
+                      {isEditing ? (
+                        <input
+                          autoFocus
+                          aria-label={`Edit cell ${rowIndex + 1}, ${columnIndex + 1}`}
+                          className="h-full w-full bg-white px-3 py-2 outline-none"
+                          value={editingCell.value}
+                          onChange={(event) => setEditingCell({ rowIndex, columnIndex, value: event.target.value })}
+                          onBlur={() => commitEdit()}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter' || event.key === 'Tab') {
+                              event.preventDefault();
+                              commitEdit(editingCell.value);
+                              setSelection((current) => moveSheetSelectionForward(current, rowCount, columnCount));
+                              focusGrid();
+                            }
+                            if (event.key === 'Escape') {
+                              event.preventDefault();
+                              setEditingCell(null);
+                              focusGrid();
+                            }
+                          }}
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          className="block h-full min-h-9 w-full px-3 py-2 text-left"
+                          onDoubleClick={() => {
+                            if (!readOnly) setEditingCell({ rowIndex, columnIndex, value: cell });
+                          }}
+                        >
+                          {cell}
+                        </button>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/sheets/index.ts
+++ b/src/components/sheets/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 Benjamin F. Hall
 // SPDX-License-Identifier: MIT
 
-export * from './git';
-export * from './components/sheets';
+export * from './SheetsEditor';
+export * from './sheetSelection';

--- a/src/components/sheets/sheetSelection.ts
+++ b/src/components/sheets/sheetSelection.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+export type SheetSelectionKind = 'cell' | 'row' | 'column';
+
+export type SheetCellPosition = {
+  rowIndex: number;
+  columnIndex: number;
+};
+
+export type SheetSelection = {
+  kind: SheetSelectionKind;
+  active: SheetCellPosition;
+  anchor: SheetCellPosition;
+};
+
+export const createCellSelection = (rowIndex: number, columnIndex: number): SheetSelection => ({
+  kind: 'cell',
+  active: { rowIndex, columnIndex },
+  anchor: { rowIndex, columnIndex }
+});
+
+export const createRowSelection = (rowIndex: number): SheetSelection => ({
+  kind: 'row',
+  active: { rowIndex, columnIndex: 0 },
+  anchor: { rowIndex, columnIndex: 0 }
+});
+
+export const createColumnSelection = (columnIndex: number): SheetSelection => ({
+  kind: 'column',
+  active: { rowIndex: 0, columnIndex },
+  anchor: { rowIndex: 0, columnIndex }
+});
+
+export const moveSheetSelectionForward = (
+  selection: SheetSelection,
+  rowCount: number,
+  columnCount: number
+): SheetSelection => {
+  const maxRowIndex = Math.max(0, rowCount - 1);
+  const maxColumnIndex = Math.max(0, columnCount - 1);
+
+  if (selection.kind === 'row') {
+    const nextColumnIndex = Math.min(maxColumnIndex, selection.active.columnIndex + 1);
+    return {
+      ...selection,
+      active: { rowIndex: selection.anchor.rowIndex, columnIndex: nextColumnIndex }
+    };
+  }
+
+  if (selection.kind === 'column') {
+    const nextRowIndex = Math.min(maxRowIndex, selection.active.rowIndex + 1);
+    return {
+      ...selection,
+      active: { rowIndex: nextRowIndex, columnIndex: selection.anchor.columnIndex }
+    };
+  }
+
+  const nextColumnIndex = selection.active.columnIndex + 1;
+  if (nextColumnIndex <= maxColumnIndex) {
+    return createCellSelection(selection.active.rowIndex, nextColumnIndex);
+  }
+
+  const nextRowIndex = Math.min(maxRowIndex, selection.active.rowIndex + 1);
+  return createCellSelection(nextRowIndex, 0);
+};
+
+export const isCellInSelection = (
+  selection: SheetSelection,
+  rowIndex: number,
+  columnIndex: number
+): boolean => {
+  if (selection.kind === 'row') return rowIndex === selection.anchor.rowIndex;
+  if (selection.kind === 'column') return columnIndex === selection.anchor.columnIndex;
+  return selection.active.rowIndex === rowIndex && selection.active.columnIndex === columnIndex;
+};
+
+export const isPrintableSheetEntryKey = (event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey'>): boolean => {
+  return event.key.length === 1 && !event.metaKey && !event.ctrlKey && !event.altKey;
+};

--- a/tests/client/SheetsEditor.test.tsx
+++ b/tests/client/SheetsEditor.test.tsx
@@ -69,12 +69,32 @@ describe('SheetsEditor', () => {
     expect(input).toHaveValue('x');
 
     await user.keyboard('yz{Enter}');
+    expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveBeenLastCalledWith([
       ['A1', 'B1', 'C1'],
       ['xyz', 'B2', 'C2'],
       ['A3', 'B3', 'C3']
     ]);
   });
+
+  it('commits keyboard edits only once when focus returns to the grid', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<SheetsEditor data={sampleData} onChange={handleChange} />);
+
+    await user.dblClick(within(screen.getAllByRole('gridcell')[0]).getByRole('button'));
+    await user.clear(screen.getByRole('textbox', { name: 'Edit cell 1, 1' }));
+    await user.keyboard('Edited{Tab}');
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenLastCalledWith([
+      ['Edited', 'B1', 'C1'],
+      ['A2', 'B2', 'C2'],
+      ['A3', 'B3', 'C3']
+    ]);
+    expect(screen.getAllByRole('gridcell')[1]).toHaveAttribute('data-active', 'true');
+  });
+
 });
 
 describe('sheet selection helpers', () => {

--- a/tests/client/SheetsEditor.test.tsx
+++ b/tests/client/SheetsEditor.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Benjamin F. Hall
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SheetsEditor } from '@/src/components/sheets/SheetsEditor';
+import { createColumnSelection, createRowSelection, moveSheetSelectionForward } from '@/src/components/sheets/sheetSelection';
+
+const sampleData = [
+  ['A1', 'B1', 'C1'],
+  ['A2', 'B2', 'C2'],
+  ['A3', 'B3', 'C3']
+];
+
+describe('SheetsEditor', () => {
+  it('selects an entire row from the row key and makes the first column active', async () => {
+    const user = userEvent.setup();
+    render(<SheetsEditor data={sampleData} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select row 2' }));
+
+    const selectedCells = screen.getAllByRole('gridcell').filter((cell) => cell.getAttribute('aria-selected') === 'true');
+    expect(selectedCells).toHaveLength(3);
+    expect(selectedCells.map((cell) => within(cell).getByRole('button').textContent)).toEqual(['A2', 'B2', 'C2']);
+    expect(within(selectedCells[0]).getByRole('button')).toHaveTextContent('A2');
+    expect(selectedCells[0]).toHaveAttribute('data-active', 'true');
+  });
+
+  it('selects an entire column from the column key and makes the first row active', async () => {
+    const user = userEvent.setup();
+    render(<SheetsEditor data={sampleData} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select column B' }));
+
+    const selectedCells = screen.getAllByRole('gridcell').filter((cell) => cell.getAttribute('aria-selected') === 'true');
+    expect(selectedCells).toHaveLength(3);
+    expect(selectedCells.map((cell) => within(cell).getByRole('button').textContent)).toEqual(['B1', 'B2', 'B3']);
+    expect(selectedCells[0]).toHaveAttribute('data-active', 'true');
+  });
+
+  it('advances the active cell through row and column selections with tab or enter', async () => {
+    const user = userEvent.setup();
+    render(<SheetsEditor data={sampleData} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select row 1' }));
+    await user.tab();
+    expect(screen.getAllByRole('gridcell')[1]).toHaveAttribute('data-active', 'true');
+    await user.keyboard('{Enter}');
+    expect(screen.getAllByRole('gridcell')[2]).toHaveAttribute('data-active', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Select column A' }));
+    await user.tab();
+    expect(screen.getAllByRole('gridcell')[3]).toHaveAttribute('data-active', 'true');
+    await user.keyboard('{Enter}');
+    expect(screen.getAllByRole('gridcell')[6]).toHaveAttribute('data-active', 'true');
+  });
+
+  it('starts editing the active cell with printable text immediately after a row key selection', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<SheetsEditor data={sampleData} onChange={handleChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select row 2' }));
+    await user.keyboard('x');
+
+    const input = screen.getByRole('textbox', { name: 'Edit cell 2, 1' });
+    expect(input).toHaveValue('x');
+
+    await user.keyboard('yz{Enter}');
+    expect(handleChange).toHaveBeenLastCalledWith([
+      ['A1', 'B1', 'C1'],
+      ['xyz', 'B2', 'C2'],
+      ['A3', 'B3', 'C3']
+    ]);
+  });
+});
+
+describe('sheet selection helpers', () => {
+  it('keeps header selections while moving active cell by one index', () => {
+    expect(moveSheetSelectionForward(createRowSelection(3), 10, 10)).toEqual({
+      kind: 'row',
+      anchor: { rowIndex: 3, columnIndex: 0 },
+      active: { rowIndex: 3, columnIndex: 1 }
+    });
+    expect(moveSheetSelectionForward(createColumnSelection(4), 10, 10)).toEqual({
+      kind: 'column',
+      anchor: { rowIndex: 0, columnIndex: 4 },
+      active: { rowIndex: 1, columnIndex: 4 }
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide spreadsheet-like UX where clicking a row or column header selects the full row/column and places an active cell inside that header selection. 
- Support industry-standard keyboard flows by making Tab/Enter advance the active cell and allow printable-key entry to immediately begin editing the active cell. 

### Description

- Add selection model and helpers in `src/components/sheets/sheetSelection.ts` for `cell`, `row`, and `column` selections including `moveSheetSelectionForward` and printable-key detection. 
- Add a reusable `SheetsEditor` component in `src/components/sheets/SheetsEditor.tsx` implementing header buttons that select full rows/columns, anchor an active cell, handle `Tab`/`Enter` navigation, and start inline editing on printable-key input. 
- Export the sheets primitives via `src/components/sheets/index.ts` and re-export from `src/index.ts` for convenience. 
- Add focused client tests in `tests/client/SheetsEditor.test.tsx` covering row/column header selection, active-cell behavior, keyboard progression, and immediate printable-key editing. 

### Testing

- Ran `npm run lint` (TypeScript typecheck + repo checks) and it completed without errors. 
- Ran `npm test -- --run tests/client/SheetsEditor.test.tsx` and the Vitest suite for the new file passed (5 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4cabbc74832b81eda05ce7ce0fb8)